### PR TITLE
Pull Axel Heider's patch branch containing support for RPi4

### DIFF
--- a/libethdrivers/include/ethdrivers/imx6.h
+++ b/libethdrivers/include/ethdrivers/imx6.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -19,5 +20,9 @@
  *                          functions.
  * @param[in] config        Platform Specific configuration data
  */
-int ethif_imx6_init(struct eth_driver *eth_driver, ps_io_ops_t io_ops, void *config);
+int
+ethif_imx6_init(
+    struct eth_driver *eth_driver,
+    ps_io_ops_t io_ops,
+    void *config);
 

--- a/libethdrivers/plat_include/imx6/ethdrivers/plat/eth_plat.h
+++ b/libethdrivers/plat_include/imx6/ethdrivers/plat/eth_plat.h
@@ -4,4 +4,6 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#pragma once
+
 #include <ethdrivers/imx6.h>

--- a/libethdrivers/src/helpers.c
+++ b/libethdrivers/src/helpers.c
@@ -17,14 +17,14 @@ dma_alloc_pin(
 {
     void *virt = ps_dma_alloc(dma_man, size, alignment, cached, PS_MEM_NORMAL);
     if (!virt) {
-        return (dma_addr_t) {0, 0};
+        return (dma_addr_t) {.virt = NULL, .phys = 0};
     }
 
     uintptr_t phys = ps_dma_pin(dma_man, virt, size);
     if (!phys) {
         /* hmm this shouldn't really happen */
         ps_dma_free(dma_man, virt, size);
-        return (dma_addr_t) {0, 0};
+        return (dma_addr_t) {.virt = NULL, .phys = 0};
     }
 
     if (!cached) {

--- a/libethdrivers/src/helpers.c
+++ b/libethdrivers/src/helpers.c
@@ -1,33 +1,46 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
 #include <ethdrivers/helpers.h>
 
+/*----------------------------------------------------------------------------*/
 dma_addr_t
-dma_alloc_pin(ps_dma_man_t *dma_man, size_t size, int cached, int alignment)
+dma_alloc_pin(
+    ps_dma_man_t *dma_man,
+    size_t size,
+    int cached,
+    int alignment)
 {
     void *virt = ps_dma_alloc(dma_man, size, alignment, cached, PS_MEM_NORMAL);
     if (!virt) {
         return (dma_addr_t) {0, 0};
     }
+
     uintptr_t phys = ps_dma_pin(dma_man, virt, size);
     if (!phys) {
         /* hmm this shouldn't really happen */
         ps_dma_free(dma_man, virt, size);
         return (dma_addr_t) {0, 0};
     }
+
     if (!cached) {
         /* Prevent any cache bombs */
         ps_dma_cache_clean_invalidate(dma_man, virt, size);
     }
+
     return (dma_addr_t) {.virt = virt, .phys = phys};
 }
 
+/*----------------------------------------------------------------------------*/
 void
-dma_unpin_free(ps_dma_man_t *dma_man, void *virt, size_t size)
+dma_unpin_free(
+    ps_dma_man_t *dma_man,
+    void *virt,
+    size_t size)
 {
     ps_dma_unpin(dma_man, virt, size);
     ps_dma_free(dma_man, virt, size);

--- a/libethdrivers/src/helpers.c
+++ b/libethdrivers/src/helpers.c
@@ -17,11 +17,14 @@ dma_alloc_pin(
 {
     void *virt = ps_dma_alloc(dma_man, size, alignment, cached, PS_MEM_NORMAL);
     if (!virt) {
+        LOG_ERROR("ps_dma_alloc() failed for size=%zu, alignment=%d",
+                  size, alignment);
         return (dma_addr_t) {.virt = NULL, .phys = 0};
     }
 
     uintptr_t phys = ps_dma_pin(dma_man, virt, size);
     if (!phys) {
+        LOG_ERROR("ps_dma_pin() failed for virt=%p, size=%zu", virt, size);
         /* hmm this shouldn't really happen */
         ps_dma_free(dma_man, virt, size);
         return (dma_addr_t) {.virt = NULL, .phys = 0};

--- a/libethdrivers/src/plat/imx6/enet.c
+++ b/libethdrivers/src/plat/imx6/enet.c
@@ -390,7 +390,7 @@ enet_set_speed(
         rcr |= RCR_RMII_10T;
         break;
     default:
-        printf("Invalid speed\n");
+        LOG_ERROR("Invalid speed");
         assert(0);
         return;
     }
@@ -608,6 +608,7 @@ enet_init(
     /* Map in the device */
     regs = RESOURCE(&io_ops->io_mapper, IMX6_ENET);
     if (regs == NULL) {
+        LOG_ERROR("ethernet controller could not be mapped");
         return NULL;
     }
     ret = (struct enet *)regs;
@@ -635,6 +636,7 @@ enet_init(
     // TODO Implement an actual clock driver for the imx8mq
     void *clock_base = RESOURCE(&io_ops->io_mapper, CCM);
     if (!clock_base) {
+        LOG_ERROR("clock controller could not be mapped");
         return NULL;
     }
 

--- a/libethdrivers/src/plat/imx6/enet.c
+++ b/libethdrivers/src/plat/imx6/enet.c
@@ -601,6 +601,7 @@ enet_init(
     uint32_t tx_phys,
     uint32_t rx_phys,
     uint32_t rx_bufsize,
+    char *mac,
     ps_io_ops_t *io_ops)
 {
     struct clock *enet_clk_ptr = NULL;
@@ -679,7 +680,7 @@ enet_init(
     regs->galr = 0;
 
     /* Set MAC and pause frame type field */
-    enet_set_mac(enet, (unsigned char *)"\0\0\0\0\0\0");
+    enet_set_mac(enet, mac);
 
     /* Configure pause frames (continues into MAC registers...) */
     regs->opd = PAUSE_OPCODE_FIELD << 16;

--- a/libethdrivers/src/plat/imx6/enet.c
+++ b/libethdrivers/src/plat/imx6/enet.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017, NXP
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -255,11 +256,15 @@ static inline enet_regs_t *enet_get_regs(struct enet *enet)
 #define PHYOP_REG_SHIFT       18
 #define PHYOP_DATA_SHIFT       0
 
+
 /******************
  *** MDIO clock ***
  ******************/
 
-static freq_t _mdc_clk_get_freq(clk_t *clk)
+/*----------------------------------------------------------------------------*/
+static freq_t
+_mdc_clk_get_freq(
+    clk_t *clk)
 {
     enet_regs_t *regs = (enet_regs_t *)clk->priv;
     uint32_t fin = clk_get_freq(clk->parent);
@@ -268,7 +273,11 @@ static freq_t _mdc_clk_get_freq(clk_t *clk)
     return fout;
 }
 
-static freq_t _mdc_clk_set_freq(clk_t *clk, freq_t hz)
+/*----------------------------------------------------------------------------*/
+static freq_t
+_mdc_clk_set_freq(
+    clk_t *clk,
+    freq_t hz)
 {
     enet_regs_t *regs = (enet_regs_t *)clk->priv;
     uint32_t fin = clk_get_freq(clk->parent);
@@ -294,16 +303,23 @@ static freq_t _mdc_clk_set_freq(clk_t *clk, freq_t hz)
     return clk_get_freq(clk);
 }
 
-static void _mdc_clk_recal(struct clock *clk)
+/*----------------------------------------------------------------------------*/
+static void
+_mdc_clk_recal(
+    struct clock *clk)
 {
     assert(0);
 }
 
-static clk_t *_mdc_clk_init(clk_t *clk)
+/*----------------------------------------------------------------------------*/
+static clk_t *
+_mdc_clk_init(
+    clk_t *clk)
 {
     return clk;
 }
 
+/*----------------------------------------------------------------------------*/
 static struct clock mdc_clk = {
     .id = CLK_CUSTOM,
     .name = "mdc_clk",
@@ -319,11 +335,16 @@ static struct clock mdc_clk = {
 };
 
 #ifdef CONFIG_PLAT_IMX8MQ_EVK
-static freq_t _enet_clk_get_freq(clk_t *clk)
+
+/*----------------------------------------------------------------------------*/
+static freq_t
+_enet_clk_get_freq(
+    clk_t *clk)
 {
     return clk->req_freq;
 }
 
+/*----------------------------------------------------------------------------*/
 static struct clock enet_clk = {
     .id = CLK_CUSTOM,
     .name = "enet_clk",
@@ -337,9 +358,15 @@ static struct clock enet_clk = {
     .sibling = NULL,
     .child = NULL,
 };
+
 #endif
 
-void enet_set_speed(struct enet *enet, int speed, int full_duplex)
+/*----------------------------------------------------------------------------*/
+void
+enet_set_speed(
+    struct enet *enet,
+    int speed,
+    int full_duplex)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     uint32_t ecr = regs->ecr;
@@ -381,7 +408,12 @@ void enet_set_speed(struct enet *enet, int speed, int full_duplex)
  *** MDIO bus ***
  ****************/
 
-int enet_mdio_read(struct enet *enet, uint16_t phy, uint16_t reg)
+/*----------------------------------------------------------------------------*/
+int
+enet_mdio_read(
+    struct enet *enet,
+        uint16_t phy,
+        uint16_t reg)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     uint32_t v;
@@ -398,7 +430,13 @@ int enet_mdio_read(struct enet *enet, uint16_t phy, uint16_t reg)
     return readl(&regs->mmfr) & 0xffff;
 }
 
-int enet_mdio_write(struct enet *enet, uint16_t phy, uint16_t reg, uint16_t data)
+/*----------------------------------------------------------------------------*/
+int
+enet_mdio_write(
+    struct enet *enet,
+    uint16_t phy,
+    uint16_t reg,
+    uint16_t data)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     uint32_t v;
@@ -416,53 +454,83 @@ int enet_mdio_write(struct enet *enet, uint16_t phy, uint16_t reg, uint16_t data
 /*******************
  *** ENET driver ***
  *******************/
-void enet_rx_enable(struct enet *enet)
+
+/*----------------------------------------------------------------------------*/
+void
+enet_rx_enable(
+    struct enet *enet)
 {
     enet_get_regs(enet)->rdar = RDAR_RDAR;
 }
 
-int enet_rx_enabled(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+int
+enet_rx_enabled(
+    struct enet *enet)
 {
     return enet_get_regs(enet)->rdar == RDAR_RDAR;
 }
 
-int enet_tx_enabled(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+int
+enet_tx_enabled(
+    struct enet *enet)
 {
     return enet_get_regs(enet)->tdar == TDAR_TDAR;
 }
 
-void enet_tx_enable(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_tx_enable(
+    struct enet *enet)
 {
     enet_get_regs(enet)->tdar = TDAR_TDAR;
 }
 
-void enet_enable(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_enable(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     regs->ecr |= ECR_ETHEREN;
 }
 
-int enet_enabled(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+int
+enet_enabled(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     return (regs->ecr & ECR_ETHEREN) != 0;
 }
 
-void enet_disable(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_disable(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     assert(!"WARNING Descriptors will be reset");
     regs->ecr &= ~ECR_ETHEREN;
 }
 
-void enet_set_mac(struct enet *enet, unsigned char *mac)
+/*----------------------------------------------------------------------------*/
+void
+enet_set_mac(
+    struct enet *enet,
+    unsigned char *mac)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     regs->palr = mac[0] << 24 | mac[1] << 16 | mac[2] << 8 | mac[3] << 0;
     regs->paur = mac[4] << 24 | mac[5] << 16 | PAUSE_FRAME_TYPE_FIELD;
 }
 
-void enet_get_mac(struct enet *enet, unsigned char *mac)
+/*----------------------------------------------------------------------------*/
+void
+enet_get_mac(
+    struct enet *enet,
+    unsigned char *mac)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     uint32_t macl = regs->palr;
@@ -477,18 +545,29 @@ void enet_get_mac(struct enet *enet, unsigned char *mac)
     mac[5] = macu >> 16;
 }
 
-void enet_enable_events(struct enet *enet, uint32_t mask)
+/*----------------------------------------------------------------------------*/
+void
+enet_enable_events(
+    struct enet *enet,
+    uint32_t mask)
 {
     assert(enet);
     enet_get_regs(enet)->eimr = mask;
 }
 
-uint32_t enet_get_events(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+uint32_t
+enet_get_events(
+    struct enet *enet)
 {
     return enet_get_regs(enet)->eir;
 }
 
-uint32_t enet_clr_events(struct enet *enet, uint32_t bits)
+/*----------------------------------------------------------------------------*/
+uint32_t
+enet_clr_events(
+    struct enet *enet,
+    uint32_t bits)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     uint32_t e = regs->eir & bits;
@@ -497,20 +576,29 @@ uint32_t enet_clr_events(struct enet *enet, uint32_t bits)
     return e;
 }
 
-void enet_prom_enable(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_prom_enable(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     regs->rcr |= RCR_PROM;
 }
 
-void enet_prom_disable(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_prom_disable(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     regs->rcr &= ~RCR_PROM;
 }
 
+/*----------------------------------------------------------------------------*/
 struct enet *
-enet_init(struct desc_data desc_data, ps_io_ops_t *io_ops)
+enet_init(
+    struct desc_data desc_data,
+    ps_io_ops_t *io_ops)
 {
     enet_regs_t *regs;
     struct enet *ret;
@@ -522,6 +610,7 @@ enet_init(struct desc_data desc_data, ps_io_ops_t *io_ops)
         return NULL;
     }
     ret = (struct enet *)regs;
+
     /* Perform reset */
     regs->ecr = ECR_RESET;
     while (regs->ecr & ECR_RESET);
@@ -531,14 +620,16 @@ enet_init(struct desc_data desc_data, ps_io_ops_t *io_ops)
     regs->eimr = 0x00000000;
     regs->eir  = 0xffffffff;
 
-#ifdef CONFIG_PLAT_IMX6
+#if defined(CONFIG_PLAT_IMX6)
+
     /* Set the ethernet clock frequency */
     clock_sys_t *clk_sys = malloc(sizeof(clock_sys_t));
     clock_sys_init(io_ops, clk_sys);
     enet_clk_ptr = clk_get_clock(clk_sys, CLK_ENET);
     clk_set_freq(enet_clk_ptr, ENET_FREQ);
-#endif
-#ifdef CONFIG_PLAT_IMX8MQ_EVK
+
+#elif defined(CONFIG_PLAT_IMX8MQ_EVK)
+
     enet_clk_ptr = &enet_clk;
     // TODO Implement an actual clock driver for the imx8mq
     void *clock_base = RESOURCE(&io_ops->io_mapper, CCM);
@@ -567,6 +658,7 @@ enet_init(struct desc_data desc_data, ps_io_ops_t *io_ops)
     /* Ungate the clocks now */
     *ccgr_enet_set = 0x3;
     *ccgr_sim_enet_set = 0x3;
+
 #endif
 
     /* Set the MDIO clock frequency */
@@ -625,7 +717,11 @@ enet_init(struct desc_data desc_data, ps_io_ops_t *io_ops)
  *** Debug and statistics ***
  ****************************/
 
-static void dump_regs(uint32_t *start, int size)
+/*----------------------------------------------------------------------------*/
+static void
+dump_regs(
+    uint32_t *start,
+    int size)
 {
     int i, j;
     uint32_t *base = start;
@@ -638,7 +734,10 @@ static void dump_regs(uint32_t *start, int size)
     }
 }
 
-void enet_dump_regs(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_dump_regs(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     printf("\nEthernet regs\n");
@@ -646,7 +745,10 @@ void enet_dump_regs(struct enet *enet)
     printf("\n");
 }
 
-void enet_clear_mib(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_clear_mib(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     /* Disable */
@@ -660,7 +762,10 @@ void enet_clear_mib(struct enet *enet)
     regs->mibc &= ~MIBC_DIS;
 }
 
-void enet_print_mib(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_print_mib(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     volatile struct mib_regs *mib = &regs->mib;
@@ -685,7 +790,10 @@ void enet_print_mib(struct enet *enet)
     regs->mibc &= ~MIBC_DIS;
 }
 
-void enet_print_state(struct enet *enet)
+/*----------------------------------------------------------------------------*/
+void
+enet_print_state(
+    struct enet *enet)
 {
     enet_regs_t *regs = enet_get_regs(enet);
     printf("Ethernet state: %s\n", (enet_enabled(enet)) ? "Active" : "Inactive");

--- a/libethdrivers/src/plat/imx6/enet.c
+++ b/libethdrivers/src/plat/imx6/enet.c
@@ -7,13 +7,14 @@
  */
 
 #include "enet.h"
-#include <stdint.h>
-#include <assert.h>
 #include "io.h"
 #include <platsupport/clock.h>
 #include "unimplemented.h"
 #include "../../debug.h"
+
+#include <stdint.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #ifdef CONFIG_PLAT_IMX6
 #define IMX6_ENET_PADDR 0x02188000

--- a/libethdrivers/src/plat/imx6/enet.c
+++ b/libethdrivers/src/plat/imx6/enet.c
@@ -598,7 +598,9 @@ enet_prom_disable(
 /*----------------------------------------------------------------------------*/
 struct enet *
 enet_init(
-    struct desc_data desc_data,
+    uint32_t tx_phys,
+    uint32_t rx_phys,
+    uint32_t rx_bufsize,
     ps_io_ops_t *io_ops)
 {
     enet_regs_t *regs;
@@ -704,9 +706,9 @@ enet_init(
     regs->racc = RACC_LINEDIS;
 
     /* DMA descriptors */
-    regs->tdsr = desc_data.tx_phys;
-    regs->rdsr = desc_data.rx_phys;
-    regs->mrbr = desc_data.rx_bufsize;
+    regs->tdsr = tx_phys;
+    regs->rdsr = rx_phys;
+    regs->mrbr = rx_bufsize;
 
     /* Receive control - Set frame length and RGMII mode */
     regs->rcr = RCR_MAX_FL(FRAME_LEN) | RCR_RGMII_EN | RCR_MII_MODE;

--- a/libethdrivers/src/plat/imx6/enet.c
+++ b/libethdrivers/src/plat/imx6/enet.c
@@ -590,6 +590,22 @@ enet_prom_disable(
 }
 
 /*----------------------------------------------------------------------------*/
+void
+enet_crc_strip_enable(struct enet* enet)
+{
+    enet_regs_t* regs = enet_get_regs(enet);
+    regs->rcr |= RCR_CRCSTRIP;
+}
+
+/*----------------------------------------------------------------------------*/
+void
+enet_crc_strip_disable(struct enet* enet)
+{
+    enet_regs_t* regs = enet_get_regs(enet);
+    regs->rcr &= ~RCR_CRCSTRIP;
+}
+
+/*----------------------------------------------------------------------------*/
 struct enet *
 enet_init(
     uint32_t tx_phys,

--- a/libethdrivers/src/plat/imx6/enet.h
+++ b/libethdrivers/src/plat/imx6/enet.h
@@ -51,6 +51,7 @@ enet_init(
     uint32_t tx_phys,
     uint32_t rx_phys,
     uint32_t rx_bufsize,
+    char *mac,
     ps_io_ops_t *io_ops);
 
 /* Read and write to the phy over the mdio interface */

--- a/libethdrivers/src/plat/imx6/enet.h
+++ b/libethdrivers/src/plat/imx6/enet.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -28,48 +29,122 @@
 
 struct enet;
 
-/* Debug */
-void enet_dump_regs(struct enet* enet);
-void enet_clear_mib(struct enet* enet);
-void enet_print_mib(struct enet* enet);
-
 struct desc_data {
     uint32_t tx_phys;
     uint32_t rx_phys;
     uint32_t rx_bufsize;
 };
 
-struct enet * enet_init(struct desc_data desc_data, ps_io_ops_t *io_ops);
+/* Debug */
+void
+enet_dump_regs(
+    struct enet *enet);
+
+void
+enet_clear_mib(
+    struct enet *enet);
+
+void
+enet_print_mib(
+    struct enet *enet);
+
+void
+enet_print_state(
+    struct enet *enet);
+
+struct enet *
+enet_init(
+    struct desc_data desc_data,
+    ps_io_ops_t *io_ops);
 
 /* Read and write to the phy over the mdio interface */
-int enet_mdio_read(struct enet * enet, uint16_t phy, uint16_t reg);
-int enet_mdio_write(struct enet * enet, uint16_t phy, uint16_t reg, uint16_t data);
+int
+enet_mdio_read(
+    struct enet *enet,
+    uint16_t phy,
+    uint16_t reg);
 
-void enet_enable(struct enet* enet);
-int enet_enabled(struct enet* enet);
-void enet_disable(struct enet* enet);
+int
+enet_mdio_write(
+    struct enet *enet,
+    uint16_t phy,
+    uint16_t reg,
+    uint16_t data);
 
-void enet_set_mac(struct enet* enet, unsigned char* mac);
-void enet_get_mac(struct enet* enet, unsigned char* mac);
+void
+enet_enable(
+    struct enet *enet);
 
-void enet_set_speed(struct enet* enet, int speed, int full_duplex);
+void
+enet_disable(
+    struct enet *enet);
+
+int
+enet_enabled(
+    struct enet *enet);
+
+void
+enet_set_mac(
+    struct enet *enet,
+    unsigned char* mac);
+
+void
+enet_get_mac(
+    struct enet *enet,
+    unsigned char* mac);
+
+void
+enet_set_speed(
+    struct enet *enet,
+    int speed,
+    int full_duplex);
+
 /* Clears ievents and returns the original value - before the clear */
-uint32_t enet_clr_events(struct enet* enet, uint32_t clr_bits);
+uint32_t
+enet_clr_events(
+    struct enet *enet,
+    uint32_t clr_bits);
+
 /* Sets the event mask */
-void enet_enable_events(struct enet* enet, uint32_t mask_bits);
+void
+enet_enable_events(
+    struct enet *enet,
+    uint32_t mask_bits);
+
 /* Returns the value of ievents */
-uint32_t enet_get_events(struct enet* enet);
+uint32_t
+enet_get_events(
+    struct enet *enet);
 
-void enet_tx_enable(struct enet* enet);
-int enet_tx_enabled(struct enet* enet);
-void enet_rx_enable(struct enet* enet);
-int enet_rx_enabled(struct enet* enet);
+void
+enet_tx_enable(
+    struct enet *enet);
 
-void enet_set_mdcclk(struct enet * enet, uint32_t fout);
-uint32_t enet_get_mdcclk(struct enet *imx_eth);
+int
+enet_tx_enabled(
+    struct enet *enet);
 
-void enet_print_state(struct enet * enet);
+void
+enet_rx_enable(
+    struct enet *enet);
 
-void enet_prom_enable(struct enet * enet);
-void enet_prom_disable(struct enet * enet);
+int
+enet_rx_enabled(
+    struct enet *enet);
 
+void
+enet_set_mdcclk(
+    struct enet *enet,
+    uint32_t fout);
+
+uint32_t
+enet_get_mdcclk(
+    struct enet *imx_eth);
+
+void
+enet_prom_enable(
+    struct enet  *enet);
+
+void
+enet_prom_disable(
+    struct enet *enet);

--- a/libethdrivers/src/plat/imx6/enet.h
+++ b/libethdrivers/src/plat/imx6/enet.h
@@ -29,12 +29,6 @@
 
 struct enet;
 
-struct desc_data {
-    uint32_t tx_phys;
-    uint32_t rx_phys;
-    uint32_t rx_bufsize;
-};
-
 /* Debug */
 void
 enet_dump_regs(
@@ -54,7 +48,9 @@ enet_print_state(
 
 struct enet *
 enet_init(
-    struct desc_data desc_data,
+    uint32_t tx_phys,
+    uint32_t rx_phys,
+    uint32_t rx_bufsize,
     ps_io_ops_t *io_ops);
 
 /* Read and write to the phy over the mdio interface */

--- a/libethdrivers/src/plat/imx6/enet.h
+++ b/libethdrivers/src/plat/imx6/enet.h
@@ -51,7 +51,7 @@ enet_init(
     uint32_t tx_phys,
     uint32_t rx_phys,
     uint32_t rx_bufsize,
-    char *mac,
+    uint64_t mac,
     ps_io_ops_t *io_ops);
 
 /* Read and write to the phy over the mdio interface */
@@ -83,12 +83,11 @@ enet_enabled(
 void
 enet_set_mac(
     struct enet *enet,
-    unsigned char* mac);
+    uint64_t mac);
 
-void
+uint64_t
 enet_get_mac(
-    struct enet *enet,
-    unsigned char* mac);
+    struct enet *enet);
 
 void
 enet_set_speed(

--- a/libethdrivers/src/plat/imx6/enet.h
+++ b/libethdrivers/src/plat/imx6/enet.h
@@ -144,3 +144,9 @@ enet_prom_enable(
 void
 enet_prom_disable(
     struct enet *enet);
+
+void enet_crc_strip_enable(
+    struct enet* enet);
+    
+void enet_crc_strip_disable(
+    struct enet* enet);

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -617,6 +617,12 @@ ethif_imx6_init(
     }
     dev->enet = enet;
 
+    /* Remove CRC (FCS) from ethernet frames when passing it to upper layers,
+     * because the NIC hardware would discard frames with an invalid checksum
+     * anyway by default. So there not much practical gain in keeping them.
+     * */
+    enet_crc_strip_enable(enet);
+
     /* Non-Promiscuous mode means that only traffic relevant for us is made
      * visible by the hardware, everything else is discarded automatically. We
      * will only see packets addressed to our MAC and broadcast/multicast

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -249,7 +249,10 @@ initialize_desc_ring(
      * size many descriptors, since then the head and tail pointers would be
      * equal, indicating empty.
      */
+    assert(dev->rx_size > 2);
     dev->rx_remain = dev->rx_size - 2;
+
+    assert(dev->tx_size > 2);
     dev->tx_remain = dev->tx_size - 2;
 
     dev->rdt = dev->rdh = dev->tdt = dev->tdh = 0;

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -674,9 +674,9 @@ ethif_imx6_init(
         phydev->speed,
         (phydev->duplex == DUPLEX_FULL) ? 1 : 0);
 
-    printf("\n  * Link speed: %d Mbps, %s-duplex *\n\n",
-           phydev->speed,
-           (phydev->duplex == DUPLEX_FULL) ? "full" : "half");
+    LOG_INFO("Link speed: %d Mbps, %s-duplex",
+             phydev->speed,
+             (phydev->duplex == DUPLEX_FULL) ? "full" : "half");
 
     udelay(100000); // why?
 

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -486,7 +486,7 @@ ethif_imx6_init(
 
     if (config == NULL) {
         LOG_ERROR("Cannot get platform info; Passed in Config Pointer NULL");
-        goto error;
+        return -1;
     }
 
     struct arm_eth_plat_config *plat_config = (struct arm_eth_plat_config *)config;
@@ -494,8 +494,10 @@ ethif_imx6_init(
     dev = (struct imx6_eth_data *)malloc(sizeof(struct imx6_eth_data));
     if (dev == NULL) {
         LOG_ERROR("Failed to allocate eth data struct");
-        goto error;
+        return -1;
     }
+
+    /* We have allocated something and need to free it on any error */
 
     dev->tx_size = CONFIG_LIB_ETHDRIVER_TX_DESC_COUNT;
     dev->rx_size = CONFIG_LIB_ETHDRIVER_RX_DESC_COUNT;

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -531,11 +531,9 @@ ethif_imx6_init(
 
     /* Initialise the RGMII interface */
     enet = enet_init(
-            (struct desc_data) {
-                .tx_phys = eth_data->tx_ring_phys,
-                .rx_phys = eth_data->rx_ring_phys,
-                .rx_bufsize = BUF_SIZE
-            },
+            eth_data->tx_ring_phys,
+            eth_data->rx_ring_phys,
+            BUF_SIZE,
             &io_ops);
     if (!enet) {
         LOG_ERROR("Failed to initialize RGMII");

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -59,8 +59,6 @@ struct imx6_eth_data {
     unsigned int rdt, rdh, tdt, tdh;
 };
 
-int setup_iomux_enet(ps_io_ops_t *io_ops);
-
 /* Receive descriptor status */
 #define RXD_EMPTY     BIT(15) /* Buffer has no data. Waiting for reception. */
 #define RXD_OWN0      BIT(14) /* Receive software ownership. R/W by user */

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -668,10 +668,22 @@ ethif_imx6_init(
 
     /* Connect the phy to the ethernet controller */
     unsigned int phy_mask = 0xffffffff;
-    if (fec_init(phy_mask, enet)) {
+    struct phy_device *phydev = fec_init(phy_mask, enet);
+    if (!phydev) {
         LOG_ERROR("Failed to initialize fec");
         goto error;
     }
+
+    enet_set_speed(
+        enet,
+        phydev->speed,
+        (phydev->duplex == DUPLEX_FULL) ? 1 : 0);
+
+    printf("\n  * Link speed: %d Mbps, %s-duplex *\n\n",
+           phydev->speed,
+           (phydev->duplex == DUPLEX_FULL) ? "full" : "half");
+
+    udelay(100000); // why?
 
     /* Start the controller */
     enet_enable(enet);

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -678,8 +678,6 @@ ethif_imx6_init(
              phydev->speed,
              (phydev->duplex == DUPLEX_FULL) ? "full" : "half");
 
-    udelay(100000); // why?
-
     /* Start the controller */
     enet_enable(enet);
 

--- a/libethdrivers/src/plat/imx6/ocotp_ctrl.c
+++ b/libethdrivers/src/plat/imx6/ocotp_ctrl.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -16,14 +17,18 @@
  * CCM_CGR2[CG6]
  */
 
-#ifdef CONFIG_PLAT_IMX6
+#if defined(CONFIG_PLAT_IMX6)
+
 #define IMX6_OCOTP_PADDR   0x021BC000
 #define IMX6_OCOTP_SIZE    0x00004000
-#endif
-#ifdef CONFIG_PLAT_IMX8MQ_EVK
+
+#elif defined(CONFIG_PLAT_IMX8MQ_EVK)
+
 #define IMX6_OCOTP_PADDR   0x30350000
 #define IMX6_OCOTP_SIZE    0x00010000
+
 #endif
+
 
 #define TIMING_WAIT(x)       ((x) << 22)
 #define TIMING_SREAD(x)      ((x) << 16)
@@ -158,23 +163,34 @@ struct ocotp {
 
 typedef volatile struct ocotp_regs ocotp_regs_t;
 
-static inline ocotp_regs_t *ocotp_get_regs(struct ocotp *ocotp)
+/*----------------------------------------------------------------------------*/
+static inline ocotp_regs_t *
+ocotp_get_regs(
+    struct ocotp *ocotp)
 {
     return (ocotp_regs_t *)ocotp;
 }
 
+/*----------------------------------------------------------------------------*/
 struct ocotp *
-ocotp_init(ps_io_mapper_t *io_mapper)
+ocotp_init(
+    ps_io_mapper_t *io_mapper)
 {
     return (struct ocotp *)RESOURCE(io_mapper, IMX6_OCOTP);
 }
 
-void ocotp_free(struct ocotp *ocotp, ps_io_mapper_t *io_mapper)
+/*----------------------------------------------------------------------------*/
+void
+ocotp_free(
+    struct ocotp *ocotp,
+    ps_io_mapper_t *io_mapper)
 {
     UNRESOURCE(io_mapper, IMX6_OCOTP, ocotp);
 }
 
-int ocotp_get_mac(struct ocotp *ocotp, unsigned char *mac)
+/*----------------------------------------------------------------------------*/
+int
+ocotp_get_mac(struct ocotp *ocotp, unsigned char *mac)
 {
     ocotp_regs_t *regs;
     uint32_t mac0;

--- a/libethdrivers/src/plat/imx6/ocotp_ctrl.c
+++ b/libethdrivers/src/plat/imx6/ocotp_ctrl.c
@@ -189,27 +189,25 @@ ocotp_free(
 }
 
 /*----------------------------------------------------------------------------*/
-int
-ocotp_get_mac(struct ocotp *ocotp, unsigned char *mac)
+uint64_t
+ocotp_get_mac(
+    struct ocotp *ocotp)
 {
-    ocotp_regs_t *regs;
-    uint32_t mac0;
-    uint32_t mac1;
     assert(ocotp);
+    ocotp_regs_t *regs = ocotp_get_regs(ocotp);
 
-    regs = ocotp_get_regs(ocotp);
-    mac0 = regs->mac0;
-    mac1 = regs->mac1;
-    if (mac0 | mac1) {
-        mac[0] = (mac1 >>  8) & 0xff;
-        mac[1] = (mac1 >>  0) & 0xff;
+    uint32_t mac0 = regs->mac0; // 0xaabbccdd
+    uint32_t mac1 = regs->mac1; // 0x????gghh
+    // make big endian integer 0x0000gghhaabbccdd for the MAC
+    uint64_t mac = ((uint64_t)((uint16_t)mac1) << 32) | mac0;
 
-        mac[2] = (mac0 >> 24) & 0xff;
-        mac[3] = (mac0 >> 16) & 0xff;
-        mac[4] = (mac0 >>  8) & 0xff;
-        mac[5] = (mac0 >>  0) & 0xff;
-        return 0;
-    } else {
-        return -1;
-    }
+    LOG_INFO("MAC: %02x:%02x:%02x:%02x:%02x:%02x",
+           (uint8_t)(mac >> 40),
+           (uint8_t)(mac >> 32),
+           (uint8_t)(mac >> 24),
+           (uint8_t)(mac >> 16),
+           (uint8_t)(mac >> 8),
+           (uint8_t)mac);
+
+    return mac;
 }

--- a/libethdrivers/src/plat/imx6/ocotp_ctrl.h
+++ b/libethdrivers/src/plat/imx6/ocotp_ctrl.h
@@ -20,7 +20,6 @@ ocotp_free(
     struct ocotp *ocotp,
     ps_io_mapper_t *io_mapper);
 
-int
+uint64_t
 ocotp_get_mac(
-    struct ocotp *ocotp,
-    unsigned char *mac);
+    struct ocotp* ocotp);

--- a/libethdrivers/src/plat/imx6/ocotp_ctrl.h
+++ b/libethdrivers/src/plat/imx6/ocotp_ctrl.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -10,8 +11,16 @@
 
 struct ocotp;
 
-struct ocotp *ocotp_init(ps_io_mapper_t *io_mapper);
-void ocotp_free(struct ocotp *ocotp, ps_io_mapper_t *io_mapper);
+struct ocotp *
+ocotp_init(
+    ps_io_mapper_t *io_mapper);
 
-int ocotp_get_mac(struct ocotp* ocotp, unsigned char *mac);
+void
+ocotp_free(
+    struct ocotp *ocotp,
+    ps_io_mapper_t *io_mapper);
 
+int
+ocotp_get_mac(
+    struct ocotp *ocotp,
+    unsigned char *mac);

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -45,7 +45,7 @@
 #undef DEBUG
 
 /*----------------------------------------------------------------------------*/
-int
+static int
 fec_phy_read(
     struct mii_dev *bus,
     int phyAddr,
@@ -58,7 +58,7 @@ fec_phy_read(
 }
 
 /*----------------------------------------------------------------------------*/
-int
+static int
 fec_phy_write(
     struct mii_dev *bus,
     int phyAddr,

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -71,30 +71,26 @@ fec_phy_write(
     return enet_mdio_write(enet, phyAddr, regAddr, data);
 }
 
-/*----------------------------------------------------------------------------
- * Halt the FEC engine
- * @param[in] dev Our device to handle
- */
-void
-fec_halt(
-    struct eth_device *dev)
-{
-#if 0
-    struct fec_priv *fec = (struct fec_priv *)dev->priv;
-    int counter = 0xffff;
-    /* issue graceful stop command to the FEC transmitter if necessary */
-    writel(FEC_TCNTRL_GTS | readl(&fec->eth->x_cntrl), &fec->eth->x_cntrl);
-    /* wait for graceful stop to register */
-    while ((counter--) && (!(readl(&fec->eth->ievent) & FEC_IEVENT_GRA))) {
-        udelay(1);
-    }
-    writel(readl(&fec->eth->ecntrl) & ~FEC_ECNTRL_ETHER_EN, &fec->eth->ecntrl);
-    fec->rbd_index = 0;
-    fec->tbd_index = 0;
-#else
-    assert(!"unimplemented");
-#endif
-}
+// /*---------------------------------------------------------------------------
+//  * Halt the FEC engine
+//  * @param[in] dev Our device to handle
+//  */
+// void
+// fec_halt(
+//     struct eth_device *dev)
+// {
+//     struct fec_priv *fec = (struct fec_priv *)dev->priv;
+//     int counter = 0xffff;
+//     /* issue graceful stop command to the FEC transmitter if necessary */
+//     writel(FEC_TCNTRL_GTS | readl(&fec->eth->x_cntrl), &fec->eth->x_cntrl);
+//     /* wait for graceful stop to register */
+//     while ((counter--) && (!(readl(&fec->eth->ievent) & FEC_IEVENT_GRA))) {
+//         udelay(1);
+//     }
+//     writel(readl(&fec->eth->ecntrl) & ~FEC_ECNTRL_ETHER_EN, &fec->eth->ecntrl);
+//     fec->rbd_index = 0;
+//     fec->tbd_index = 0;
+// }
 
 /*----------------------------------------------------------------------------*/
 int

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -1,5 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright 2020, HENSOLDT Cyber GmbH
  */
 
 /*
@@ -56,22 +57,36 @@
 
 #undef DEBUG
 
-int fec_phy_read(struct mii_dev *bus, int phyAddr, int dev_addr, int regAddr)
+/*----------------------------------------------------------------------------*/
+int
+fec_phy_read(
+    struct mii_dev *bus,
+    int phyAddr,
+    int dev_addr,
+    int regAddr)
 {
     return enet_mdio_read((struct enet *)bus->priv, phyAddr, regAddr);
 }
 
-int fec_phy_write(struct mii_dev *bus, int phyAddr, int dev_addr, int regAddr,
-                  uint16_t data)
+/*----------------------------------------------------------------------------*/
+int
+fec_phy_write(
+    struct mii_dev *bus,
+    int phyAddr,
+    int dev_addr,
+    int regAddr,
+    uint16_t data)
 {
     return enet_mdio_write((struct enet *)bus->priv, phyAddr, regAddr, data);
 }
 
-/**
+/*----------------------------------------------------------------------------
  * Halt the FEC engine
  * @param[in] dev Our device to handle
  */
-void fec_halt(struct eth_device *dev)
+void
+fec_halt(
+    struct eth_device *dev)
 {
 #if 0
     struct fec_priv *fec = (struct fec_priv *)dev->priv;
@@ -89,7 +104,12 @@ void fec_halt(struct eth_device *dev)
     assert(!"unimplemented");
 #endif
 }
-int fec_init(unsigned phy_mask, struct enet *enet)
+
+/*----------------------------------------------------------------------------*/
+int
+fec_init(
+    unsigned phy_mask,
+    struct enet *enet)
 {
     struct eth_device *edev;
     struct phy_device *phydev;
@@ -119,7 +139,11 @@ int fec_init(unsigned phy_mask, struct enet *enet)
     }
 
     /****** Configure phy ******/
-    phydev = phy_connect_by_mask(bus, phy_mask, edev, PHY_INTERFACE_MODE_RGMII);
+    phydev = phy_connect_by_mask(
+                bus,
+                phy_mask,
+                edev,
+                PHY_INTERFACE_MODE_RGMII);
     if (!phydev) {
         return -1;
     }

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -117,6 +117,7 @@ fec_init(
     /* Allocate the mdio bus */
     bus = mdio_alloc();
     if (!bus) {
+        LOG_ERROR("Could not allocate MDIO");
         return -1;
     }
     bus->read = fec_phy_read;
@@ -125,6 +126,7 @@ fec_init(
     strcpy(bus->name, edev->name);
     ret = mdio_register(bus);
     if (ret) {
+        LOG_ERROR("Could not register MDIO, code %d", ret);
         free(bus);
         return -1;
     }
@@ -136,6 +138,7 @@ fec_init(
                 edev,
                 PHY_INTERFACE_MODE_RGMII);
     if (!phydev) {
+        LOG_ERROR("Could not connect to PHY");
         return -1;
     }
 
@@ -168,7 +171,7 @@ fec_init(
     /* Start up the PHY */
     ret = ksz9021_startup(phydev);
     if (ret) {
-        printf("Could not initialize PHY %s\n", phydev->dev->name);
+        LOG_ERROR("Could not initialize PHY '%s', code %d", phydev->dev->name, ret);
         return ret;
     }
 

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -62,10 +62,12 @@ int
 fec_phy_read(
     struct mii_dev *bus,
     int phyAddr,
-    int dev_addr,
+    UNUSED int dev_addr,
     int regAddr)
 {
-    return enet_mdio_read((struct enet *)bus->priv, phyAddr, regAddr);
+    struct enet *enet = (struct enet *)bus->priv;
+    assert(enet);
+    return enet_mdio_read(enet, phyAddr, regAddr);
 }
 
 /*----------------------------------------------------------------------------*/
@@ -73,11 +75,13 @@ int
 fec_phy_write(
     struct mii_dev *bus,
     int phyAddr,
-    int dev_addr,
+    UNUSED int dev_addr,
     int regAddr,
     uint16_t data)
 {
-    return enet_mdio_write((struct enet *)bus->priv, phyAddr, regAddr, data);
+    struct enet *enet = (struct enet *)bus->priv;
+    assert(enet);
+    return enet_mdio_write(enet, phyAddr, regAddr, data);
 }
 
 /*----------------------------------------------------------------------------
@@ -108,7 +112,7 @@ fec_halt(
 /*----------------------------------------------------------------------------*/
 int
 fec_init(
-    unsigned phy_mask,
+    unsigned int phy_mask,
     struct enet *enet)
 {
     struct eth_device *edev;

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -9,6 +9,7 @@
  * (C) Copyright 2007 Pengutronix, Sascha Hauer <s.hauer@pengutronix.de>
  * (C) Copyright 2007 Pengutronix, Juergen Beisert <j.beisert@pengutronix.de>
  * (C) Copyright 2018, NXP
+ * (C) Copyright 2020, HENSOLDT Cyber GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -123,37 +124,42 @@ int fec_init(unsigned phy_mask, struct enet *enet)
         return -1;
     }
 
-    if (config_set(CONFIG_PLAT_IMX8MQ_EVK)) {
-        /* enable rgmii rxc skew and phy mode select to RGMII copper */
-        phy_write(phydev, MDIO_DEVAD_NONE, 0x1d, 0x1f);
-        phy_write(phydev, MDIO_DEVAD_NONE, 0x1e, 0x8);
-        phy_write(phydev, MDIO_DEVAD_NONE, 0x1d, 0x05);
-        phy_write(phydev, MDIO_DEVAD_NONE, 0x1e, 0x100);
+#if defined(CONFIG_PLAT_IMX8MQ_EVK)
 
-        if (phydev->drv->config) {
-            phydev->drv->config(phydev);
-        }
+    /* enable rgmii rxc skew and phy mode select to RGMII copper */
+    phy_write(phydev, MDIO_DEVAD_NONE, 0x1d, 0x1f);
+    phy_write(phydev, MDIO_DEVAD_NONE, 0x1e, 0x8);
+    phy_write(phydev, MDIO_DEVAD_NONE, 0x1d, 0x05);
+    phy_write(phydev, MDIO_DEVAD_NONE, 0x1e, 0x100);
 
-        if (phydev->drv->startup) {
-            phydev->drv->startup(phydev);
-        }
-    } else if (config_set(CONFIG_PLAT_IMX6)) {
-        /* min rx data delay */
-        ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_RX_DATA_SKEW, 0x0);
-        /* min tx data delay */
-        ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_TX_DATA_SKEW, 0x0);
-        /* max rx/tx clock delay, min rx/tx control */
-        ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_CLOCK_SKEW, 0xf0f0);
-        ksz9021_config(phydev);
-
-        /* Start up the PHY */
-        ret = ksz9021_startup(phydev);
-        if (ret) {
-            printf("Could not initialize PHY %s\n", phydev->dev->name);
-            return ret;
-        }
-
+    if (phydev->drv->config) {
+        phydev->drv->config(phydev);
     }
+
+    if (phydev->drv->startup) {
+        phydev->drv->startup(phydev);
+    }
+
+#elif defined(CONFIG_PLAT_IMX6)
+
+    /* min rx data delay */
+    ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_RX_DATA_SKEW, 0x0);
+    /* min tx data delay */
+    ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_TX_DATA_SKEW, 0x0);
+    /* max rx/tx clock delay, min rx/tx control */
+    ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_CLOCK_SKEW, 0xf0f0);
+    ksz9021_config(phydev);
+
+    /* Start up the PHY */
+    ret = ksz9021_startup(phydev);
+    if (ret) {
+        printf("Could not initialize PHY %s\n", phydev->dev->name);
+        return ret;
+    }
+
+#else
+#error "unsupported platform"
+#endif
 
     printf("\n  * Link speed: %4i Mbps, ", phydev->speed);
     if (phydev->duplex == DUPLEX_FULL) {

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -41,19 +41,6 @@
 #include <string.h>
 #include "../enet.h"
 #include "../ocotp_ctrl.h"
-/*
- * Timeout the transfer after 5 mS. This is usually a bit more, since
- * the code in the tightloops this timeout is used in adds some overhead.
- */
-#define FEC_XFER_TIMEOUT    5000
-
-#ifndef CONFIG_MII
-#error "CONFIG_MII has to be defined!"
-#endif
-
-#ifndef CONFIG_FEC_XCV_TYPE
-#define CONFIG_FEC_XCV_TYPE MII100
-#endif
 
 #undef DEBUG
 

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.c
@@ -139,12 +139,21 @@ fec_init(
 
 #elif defined(CONFIG_PLAT_IMX6)
 
-    /* min rx data delay */
-    ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_RX_DATA_SKEW, 0x0);
-    /* min tx data delay */
-    ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_TX_DATA_SKEW, 0x0);
-    /* max rx/tx clock delay, min rx/tx control */
-    ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_CLOCK_SKEW, 0xf0f0);
+    if (0x00221610 == (phydev->phy_id & 0xfffffff0)) /* ignore silicon rev */
+    {
+        /* min rx data delay */
+        ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_RX_DATA_SKEW, 0x0);
+        /* min tx data delay */
+        ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_TX_DATA_SKEW, 0x0);
+        /* max rx/tx clock delay, min rx/tx control */
+        ksz9021_phy_extended_write(phydev, MII_KSZ9021_EXT_RGMII_CLOCK_SKEW, 0xf0f0);
+    }
+    else if (0x0007c0d1 == phydev->phy_id) {
+        /* seems we are running on QEMU, no special init for the emulated PHY */
+    }
+    else {
+        LOG_WARN("SABRE: unexpected PHY with ID 0x%x", phydev->phy_id);
+    }
 
 #else
 #error "unsupported platform"

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.h
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.h
@@ -3,6 +3,7 @@
  */
 
 /*
+ * (C) Copyright 2020, HENSOLDT Cyber GmbH
  * (C) Copyright 2009 Ilya Yanok, Emcraft Systems Ltd <yanok@emcraft.com>
  * (C) Copyright 2008 Armadeus Systems, nc
  * (C) Copyright 2008 Eric Jarrige <eric.jarrige@armadeus.org>
@@ -36,53 +37,56 @@
 
 #include "../enet.h"
 
-#define PKTSIZE			1518
-#define PKTSIZE_ALIGN		1536
+#define PKTSIZE         1518
+#define PKTSIZE_ALIGN   1536
 
 struct eth_device {
-	char name[16];
-	unsigned char enetaddr[6];
-	int iobase;
-	int state;
-	struct fec_priv *priv;
-        int (*write_hwaddr)(struct eth_device *dev);
+    char name[16];
+    unsigned char enetaddr[6];
+    int iobase;
+    int state;
+    struct fec_priv *priv;
+    int (*write_hwaddr)(struct eth_device *dev);
 };
 
-int fec_init(unsigned phy_mask, struct enet* enet);
+int
+fec_init(
+    unsigned phy_mask,
+    struct enet *enet);
 
-#define FEC_RCNTRL_MAX_FL_SHIFT		16
-#define FEC_RCNTRL_LOOP			0x00000001
-#define FEC_RCNTRL_DRT			0x00000002
-#define FEC_RCNTRL_MII_MODE		0x00000004
-#define FEC_RCNTRL_PROM			0x00000008
-#define FEC_RCNTRL_BC_REJ		0x00000010
-#define FEC_RCNTRL_FCE			0x00000020
-#define FEC_RCNTRL_RGMII		0x00000040
-#define FEC_RCNTRL_RMII			0x00000100
-#define FEC_RCNTRL_RMII_10T		0x00000200
+#define FEC_RCNTRL_MAX_FL_SHIFT     16
+#define FEC_RCNTRL_LOOP             0x00000001
+#define FEC_RCNTRL_DRT              0x00000002
+#define FEC_RCNTRL_MII_MODE         0x00000004
+#define FEC_RCNTRL_PROM             0x00000008
+#define FEC_RCNTRL_BC_REJ           0x00000010
+#define FEC_RCNTRL_FCE              0x00000020
+#define FEC_RCNTRL_RGMII            0x00000040
+#define FEC_RCNTRL_RMII             0x00000100
+#define FEC_RCNTRL_RMII_10T         0x00000200
 
-#define FEC_TCNTRL_GTS			0x00000001
-#define FEC_TCNTRL_HBC			0x00000002
-#define FEC_TCNTRL_FDEN			0x00000004
-#define FEC_TCNTRL_TFC_PAUSE		0x00000008
-#define FEC_TCNTRL_RFC_PAUSE		0x00000010
+#define FEC_TCNTRL_GTS              0x00000001
+#define FEC_TCNTRL_HBC              0x00000002
+#define FEC_TCNTRL_FDEN             0x00000004
+#define FEC_TCNTRL_TFC_PAUSE        0x00000008
+#define FEC_TCNTRL_RFC_PAUSE        0x00000010
 
-#define FEC_ECNTRL_RESET		0x00000001	/* reset the FEC */
-#define FEC_ECNTRL_ETHER_EN		0x00000002	/* enable the FEC */
-#define FEC_ECNTRL_SPEED		0x00000020
-#define FEC_ECNTRL_DBSWAP		0x00000100
+#define FEC_ECNTRL_RESET            0x00000001  /* reset the FEC */
+#define FEC_ECNTRL_ETHER_EN         0x00000002  /* enable the FEC */
+#define FEC_ECNTRL_SPEED            0x00000020
+#define FEC_ECNTRL_DBSWAP           0x00000100
 
-#define FEC_X_WMRK_STRFWD		0x00000100
+#define FEC_X_WMRK_STRFWD           0x00000100
 
 /**
  * @brief i.MX27-FEC private structure
  */
 struct fec_priv {
 #ifdef CONFIG_PHYLIB
-	int phy_mask;
-	struct phy_device *phydev;
+    int phy_mask;
+    struct phy_device *phydev;
 #else
-	int phy_id;
-	int (*mii_postcall)(int);
+    int phy_id;
+    int (*mii_postcall)(int);
 #endif
 };

--- a/libethdrivers/src/plat/imx6/uboot/fec_mxc.h
+++ b/libethdrivers/src/plat/imx6/uboot/fec_mxc.h
@@ -49,9 +49,9 @@ struct eth_device {
     int (*write_hwaddr)(struct eth_device *dev);
 };
 
-int
+struct phy_device *
 fec_init(
-    unsigned phy_mask,
+    unsigned phy_mask, 
     struct enet *enet);
 
 #define FEC_RCNTRL_MAX_FL_SHIFT     16

--- a/libethdrivers/src/plat/imx6/uboot/imx8mq_pins.h
+++ b/libethdrivers/src/plat/imx6/uboot/imx8mq_pins.h
@@ -4,6 +4,7 @@
 
 /*
  * Copyright (C) 2017 NXP
+ * Copyright (C) 2020, HENSOLDT Cyber GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -23,7 +24,11 @@
 
 #pragma once
 
-#include "mx6qsabrelite.h"
+#include "mx6_pins.h"
+
+#ifndef CONFIG_PLAT_IMX8MQ_EVK
+#error "CONFIG_PLAT_IMX8MQ_EVK must be defined to use this file"
+#endif
 
 enum {
     IMX8MQ_PAD_GPIO1_IO00__GPIO1_IO0                    = IOMUX_PAD(0x0290, 0x0028, 0, 0x0000, 0, 0),

--- a/libethdrivers/src/plat/imx6/uboot/mx6_pins.h
+++ b/libethdrivers/src/plat/imx6/uboot/mx6_pins.h
@@ -1,0 +1,131 @@
+/*
+ * @TAG(OTHER_GPL)
+ */
+
+/*
+ * Copyright (C) 2011 Freescale Semiconductor, Inc. All Rights Reserved.
+ * Copyright (C) 2020, HENSOLDT Cyber GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Auto Generate file, please don't edit it
+ *
+ */
+
+#pragma once
+
+#include <utils/util.h>
+#include <stdint.h>
+
+#define NO_PAD_CTRL             BIT(17)
+
+#define PAD_CTL_HYS             BIT(16)
+
+
+#ifdef CONFIG_PLAT_IMX6SX
+
+// according to u-boot, this setting apply to all i.MX6 platforms
+
+#define PAD_CTL_PUS_100K_DOWN   (0 << 14 | PAD_CTL_PUE)
+#define PAD_CTL_PUS_47K_UP      (1 << 14 | PAD_CTL_PUE)
+#define PAD_CTL_PUS_100K_UP     (2 << 14 | PAD_CTL_PUE)
+#define PAD_CTL_PUS_22K_UP      (3 << 14 | PAD_CTL_PUE)
+
+#define PAD_CTL_PUE             ( BIT(13) | PAD_CTL_PKE)
+
+#else
+
+// it's a bit unclear if this just works by chance or some bits do not really
+// matter on some platforms
+
+#define PAD_CTL_PUS_100K_DOWN   (0 << 14)
+#define PAD_CTL_PUS_47K_UP      (1 << 14)
+#define PAD_CTL_PUS_100K_UP     (2 << 14)
+#define PAD_CTL_PUS_22K_UP      (3 << 14)
+
+#define PAD_CTL_PUE             BIT(13)
+
+#endif
+
+
+#define PAD_CTL_PKE             BIT(12)
+
+#define PAD_CTL_ODE             BIT(11)
+
+// u-boot 2018.07; iomux-v3.h has a spacial handling for i.MX6 SoloLite only,
+// #if defined(CONFIG_MX6SL)
+// #define PAD_CTL_SPEED_LOW    (1 << 6)
+// #else
+#define PAD_CTL_SPEED_LOW       (0 << 6)
+// #endif
+#define PAD_CTL_SPEED_MED       (2 << 6)
+#define PAD_CTL_SPEED_HIGH      (3 << 6)
+
+#define PAD_CTL_DSE_DISABLE     (0 << 3)
+#define PAD_CTL_DSE_240ohm      (1 << 3)
+#define PAD_CTL_DSE_120ohm      (2 << 3)
+#define PAD_CTL_DSE_80ohm       (3 << 3)
+#define PAD_CTL_DSE_60ohm       (4 << 3)
+#define PAD_CTL_DSE_48ohm       (5 << 3)
+#define PAD_CTL_DSE_40ohm       (6 << 3)
+#define PAD_CTL_DSE_34ohm       (7 << 3)
+
+#define PAD_CTL_SRE_SLOW        (0 << 0)
+#define PAD_CTL_SRE_FAST        (1 << 0)
+
+#define NO_MUX_I                0
+#define NO_PAD_I                0
+
+typedef uint64_t iomux_v3_cfg_t;
+
+#define MUX_CTRL_OFS_SHIFT          0
+#define MUX_CTRL_OFS(x)             ((iomux_v3_cfg_t)(x) << MUX_CTRL_OFS_SHIFT)
+#define MUX_CTRL_OFS_MASK           MUX_CTRL_OFS(0xfff)
+
+#define MUX_PAD_CTRL_OFS_SHIFT      12
+#define MUX_PAD_CTRL_OFS(x)         ((iomux_v3_cfg_t)(x) << MUX_PAD_CTRL_OFS_SHIFT)
+#define MUX_PAD_CTRL_OFS_MASK       MUX_PAD_CTRL_OFS(0xfff)
+
+#define MUX_SEL_INPUT_OFS_SHIFT     24
+#define MUX_SEL_INPUT_OFS(x)        ((iomux_v3_cfg_t)(x) << MUX_SEL_INPUT_OFS_SHIFT)
+#define MUX_SEL_INPUT_OFS_MASK      MUX_SEL_INPUT_OFS(0xfff)
+
+#define MUX_MODE_SHIFT              36
+#define MUX_MODE(x)                 ((iomux_v3_cfg_t)(x) << MUX_MODE_SHIFT)
+#define MUX_MODE_MASK               MUX_MODE(0x3f)
+
+#define MUX_PAD_CTRL_SHIFT          42
+#define MUX_PAD_CTRL(x)             ((iomux_v3_cfg_t)(x) << MUX_PAD_CTRL_SHIFT)
+#define MUX_PAD_CTRL_MASK           MUX_PAD_CTRL(0x3ffff)
+
+#define MUX_SEL_INPUT_SHIFT         60
+#define MUX_SEL_INPUT(x)            ((iomux_v3_cfg_t)(x) << MUX_SEL_INPUT_SHIFT)
+#define MUX_SEL_INPUT_MASK          MUX_SEL_INPUT(0xf)
+
+#define IOMUX_PAD( \
+            pad_ctrl_ofs, \
+            mux_ctrl_ofs, \
+            mux_mode, \
+            sel_input_ofs,  \
+            sel_input, \
+            pad_ctrl) \
+    ( MUX_CTRL_OFS(mux_ctrl_ofs) | \
+      MUX_PAD_CTRL_OFS(pad_ctrl_ofs) | \
+      MUX_SEL_INPUT_OFS(sel_input_ofs) | \
+      MUX_MODE(mux_mode) | \
+      MUX_PAD_CTRL(pad_ctrl) | \
+      MUX_SEL_INPUT(sel_input) )
+
+#define IOMUX_CONFIG_SION       BIT(4)

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -50,108 +50,52 @@
 #define IOMUXC_SIZE      0x10000
 #endif
 
-#define ENET_PAD_CTRL  (PAD_CTL_PKE | PAD_CTL_PUE |     \
-    PAD_CTL_PUS_100K_UP | PAD_CTL_SPEED_MED   |     \
-    PAD_CTL_DSE_40ohm   | PAD_CTL_HYS)
-
-static iomux_v3_cfg_t const enet_pads1[] = {
-    MX6Q_PAD_ENET_MDIO__ENET_MDIO       | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_ENET_MDC__ENET_MDC     | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_TXC__ENET_RGMII_TXC  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_TD0__ENET_RGMII_TD0  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_TD1__ENET_RGMII_TD1  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_TD2__ENET_RGMII_TD2  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_TD3__ENET_RGMII_TD3  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_TX_CTL__RGMII_TX_CTL | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_ENET_REF_CLK__ENET_TX_CLK  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    /* pin 35 - 1 (PHY_AD2) on reset */
-    MX6Q_PAD_RGMII_RXC__GPIO_6_30       | MUX_PAD_CTRL(NO_PAD_CTRL),
-    /* pin 32 - 1 - (MODE0) all */
-    MX6Q_PAD_RGMII_RD0__GPIO_6_25       | MUX_PAD_CTRL(NO_PAD_CTRL),
-    /* pin 31 - 1 - (MODE1) all */
-    MX6Q_PAD_RGMII_RD1__GPIO_6_27       | MUX_PAD_CTRL(NO_PAD_CTRL),
-    /* pin 28 - 1 - (MODE2) all */
-    MX6Q_PAD_RGMII_RD2__GPIO_6_28       | MUX_PAD_CTRL(NO_PAD_CTRL),
-    /* pin 27 - 1 - (MODE3) all */
-    MX6Q_PAD_RGMII_RD3__GPIO_6_29       | MUX_PAD_CTRL(NO_PAD_CTRL),
-    /* pin 33 - 1 - (CLK125_EN) 125Mhz clockout enabled */
-    MX6Q_PAD_RGMII_RX_CTL__GPIO_6_24    | MUX_PAD_CTRL(NO_PAD_CTRL),
-    /* pin 42 PHY nRST */
-    MX6Q_PAD_EIM_D23__GPIO_3_23     | MUX_PAD_CTRL(NO_PAD_CTRL),
-};
-
-static iomux_v3_cfg_t const enet_pads2[] = {
-    MX6Q_PAD_RGMII_RXC__ENET_RGMII_RXC  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_RD0__ENET_RGMII_RD0  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_RD1__ENET_RGMII_RD1  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_RD2__ENET_RGMII_RD2  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_RD3__ENET_RGMII_RD3  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-    MX6Q_PAD_RGMII_RX_CTL__RGMII_RX_CTL | MUX_PAD_CTRL(ENET_PAD_CTRL),
-};
-
-static iomux_v3_cfg_t const fec1_pads[] = {
-    /* see the IMX8 reference manual for what the options mean,
-     * Section 8.2.4 i.e. IOMUXC_SW_PAD_CTL_PAD_* registers */
-    IMX8MQ_PAD_ENET_MDC__ENET_MDC | MUX_PAD_CTRL(0x3),
-    IMX8MQ_PAD_ENET_MDIO__ENET_MDIO | MUX_PAD_CTRL(0x23),
-    IMX8MQ_PAD_ENET_TD3__ENET_RGMII_TD3 | MUX_PAD_CTRL(0x1f),
-    IMX8MQ_PAD_ENET_TD2__ENET_RGMII_TD2 | MUX_PAD_CTRL(0x1f),
-    IMX8MQ_PAD_ENET_TD1__ENET_RGMII_TD1 | MUX_PAD_CTRL(0x1f),
-    IMX8MQ_PAD_ENET_TD0__ENET_RGMII_TD0 | MUX_PAD_CTRL(0x1f),
-    IMX8MQ_PAD_ENET_RD3__ENET_RGMII_RD3 | MUX_PAD_CTRL(0x91),
-    IMX8MQ_PAD_ENET_RD2__ENET_RGMII_RD2 | MUX_PAD_CTRL(0x91),
-    IMX8MQ_PAD_ENET_RD1__ENET_RGMII_RD1 | MUX_PAD_CTRL(0x91),
-    IMX8MQ_PAD_ENET_RD0__ENET_RGMII_RD0 | MUX_PAD_CTRL(0x91),
-    IMX8MQ_PAD_ENET_TXC__ENET_RGMII_TXC | MUX_PAD_CTRL(0x1f),
-    IMX8MQ_PAD_ENET_RXC__ENET_RGMII_RXC | MUX_PAD_CTRL(0x91),
-    IMX8MQ_PAD_ENET_TX_CTL__ENET_RGMII_TX_CTL | MUX_PAD_CTRL(0x1f),
-    IMX8MQ_PAD_ENET_RX_CTL__ENET_RGMII_RX_CTL | MUX_PAD_CTRL(0x91),
-    IMX8MQ_PAD_GPIO1_IO09__GPIO1_IO9 | MUX_PAD_CTRL(0x19)
-};
-
 /*
- * configures a single pad in the iomuxer
+ * configure pads in the IOMUX
  */
-static int imx_iomux_v3_setup_pad(void *base, iomux_v3_cfg_t pad)
+static void imx_iomux_v3_setup_multiple_pads(
+    void *base,
+    iomux_v3_cfg_t const *pad_list,
+    unsigned int count)
 {
-    uint32_t mux_ctrl_ofs = (pad & MUX_CTRL_OFS_MASK) >> MUX_CTRL_OFS_SHIFT;
-    uint32_t mux_mode = (pad & MUX_MODE_MASK) >> MUX_MODE_SHIFT;
-    uint32_t sel_input_ofs = (pad & MUX_SEL_INPUT_OFS_MASK) >> MUX_SEL_INPUT_OFS_SHIFT;
-    uint32_t sel_input = (pad & MUX_SEL_INPUT_MASK) >> MUX_SEL_INPUT_SHIFT;
-    uint32_t pad_ctrl_ofs = (pad & MUX_PAD_CTRL_OFS_MASK) >> MUX_PAD_CTRL_OFS_SHIFT;
-    uint32_t pad_ctrl = (pad & MUX_PAD_CTRL_MASK) >> MUX_PAD_CTRL_SHIFT;
+    for (unsigned int i = 0; i < count; i++) {
+        iomux_v3_cfg_t pad = pad_list[i];
 
-    if (mux_ctrl_ofs) {
-        __raw_writel(mux_mode, base + mux_ctrl_ofs);
-    }
-
-    if (sel_input_ofs) {
-        __raw_writel(sel_input, base + sel_input_ofs);
-    }
-
-    if (!(pad_ctrl & NO_PAD_CTRL) && pad_ctrl_ofs) {
-        __raw_writel(pad_ctrl, base + pad_ctrl_ofs);
-    }
-
-    return 0;
-}
-
-static int imx_iomux_v3_setup_multiple_pads(void *base, iomux_v3_cfg_t const *pad_list,
-                                            unsigned count)
-{
-    iomux_v3_cfg_t const *p = pad_list;
-    int i;
-    int ret;
-
-    for (i = 0; i < count; i++) {
-        ret = imx_iomux_v3_setup_pad(base, *p);
-        if (ret) {
-            return ret;
+        // set mode
+        uint32_t mux_ctrl_ofs = (pad & MUX_CTRL_OFS_MASK) >> MUX_CTRL_OFS_SHIFT;
+        if (mux_ctrl_ofs) {
+            uint32_t mux_mode = (pad & MUX_MODE_MASK) >> MUX_MODE_SHIFT;
+            __raw_writel(mux_mode, base + mux_ctrl_ofs);
         }
-        p++;
+
+        // set input selector
+        uint32_t sel_input_ofs = (pad & MUX_SEL_INPUT_OFS_MASK) >> MUX_SEL_INPUT_OFS_SHIFT;
+        if (sel_input_ofs) {
+            uint32_t sel_input = (pad & MUX_SEL_INPUT_MASK) >> MUX_SEL_INPUT_SHIFT;
+            __raw_writel(sel_input, base + sel_input_ofs);
+        }
+
+        // set pad control
+        uint32_t pad_ctrl_ofs = (pad & MUX_PAD_CTRL_OFS_MASK) >> MUX_PAD_CTRL_OFS_SHIFT;
+        if (pad_ctrl_ofs) {
+            uint32_t pad_ctrl = (pad & MUX_PAD_CTRL_MASK) >> MUX_PAD_CTRL_SHIFT;
+            if (!(pad_ctrl & NO_PAD_CTRL)) {
+                __raw_writel(pad_ctrl, base + pad_ctrl_ofs);
+            }
+        }
     }
-    return 0;
 }
+
+#define IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(_base_, ...) \
+    do { \
+        iomux_v3_cfg_t const pad_cfg[] = { __VA_ARGS__ }; \
+        imx_iomux_v3_setup_multiple_pads( \
+            _base_, \
+            pad_cfg, \
+            ARRAY_SIZE(pad_cfg) ); \
+    } while(0)
+
+
 
 int setup_iomux_enet(ps_io_ops_t *io_ops)
 {
@@ -171,10 +115,26 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
 
 #if defined(CONFIG_PLAT_IMX8MQ_EVK)
 
-    ret = imx_iomux_v3_setup_multiple_pads(base, fec1_pads, ARRAY_SIZE(fec1_pads));
-    if (ret) {
-        return ret;
-    }
+    /* see the IMX8 reference manual for what the options mean,
+     * Section 8.2.4 i.e. IOMUXC_SW_PAD_CTL_PAD_* registers */
+    IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(
+        base,
+        IMX8MQ_PAD_ENET_MDC__ENET_MDC | MUX_PAD_CTRL(0x3),
+        IMX8MQ_PAD_ENET_MDIO__ENET_MDIO | MUX_PAD_CTRL(0x23),
+        IMX8MQ_PAD_ENET_TD3__ENET_RGMII_TD3 | MUX_PAD_CTRL(0x1f),
+        IMX8MQ_PAD_ENET_TD2__ENET_RGMII_TD2 | MUX_PAD_CTRL(0x1f),
+        IMX8MQ_PAD_ENET_TD1__ENET_RGMII_TD1 | MUX_PAD_CTRL(0x1f),
+        IMX8MQ_PAD_ENET_TD0__ENET_RGMII_TD0 | MUX_PAD_CTRL(0x1f),
+        IMX8MQ_PAD_ENET_RD3__ENET_RGMII_RD3 | MUX_PAD_CTRL(0x91),
+        IMX8MQ_PAD_ENET_RD2__ENET_RGMII_RD2 | MUX_PAD_CTRL(0x91),
+        IMX8MQ_PAD_ENET_RD1__ENET_RGMII_RD1 | MUX_PAD_CTRL(0x91),
+        IMX8MQ_PAD_ENET_RD0__ENET_RGMII_RD0 | MUX_PAD_CTRL(0x91),
+        IMX8MQ_PAD_ENET_TXC__ENET_RGMII_TXC | MUX_PAD_CTRL(0x1f),
+        IMX8MQ_PAD_ENET_RXC__ENET_RGMII_RXC | MUX_PAD_CTRL(0x91),
+        IMX8MQ_PAD_ENET_TX_CTL__ENET_RGMII_TX_CTL | MUX_PAD_CTRL(0x1f),
+        IMX8MQ_PAD_ENET_RX_CTL__ENET_RGMII_RX_CTL | MUX_PAD_CTRL(0x91),
+        IMX8MQ_PAD_GPIO1_IO09__GPIO1_IO9 | MUX_PAD_CTRL(0x19)
+    );
     gpio_direction_output(IMX_GPIO_NR(1, 9), 0, io_ops);
     udelay(500);
     gpio_direction_output(IMX_GPIO_NR(1, 9), 1, io_ops);
@@ -191,19 +151,51 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
     gpio_direction_output(IMX_GPIO_NR(6, 27), 1, io_ops);
     gpio_direction_output(IMX_GPIO_NR(6, 28), 1, io_ops);
     gpio_direction_output(IMX_GPIO_NR(6, 29), 1, io_ops);
-    ret = imx_iomux_v3_setup_multiple_pads(base, enet_pads1, ARRAY_SIZE(enet_pads1));
-    if (ret) {
-        return ret;
-    }
+
+#define ENET_PAD_CTRL  (PAD_CTL_PKE | PAD_CTL_PUE | PAD_CTL_PUS_100K_UP | \
+                        PAD_CTL_SPEED_MED | PAD_CTL_DSE_40ohm | PAD_CTL_HYS)
+
+    IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(
+        base,
+        MX6Q_PAD_ENET_MDIO__ENET_MDIO       | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_ENET_MDC__ENET_MDC     | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_TXC__ENET_RGMII_TXC  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_TD0__ENET_RGMII_TD0  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_TD1__ENET_RGMII_TD1  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_TD2__ENET_RGMII_TD2  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_TD3__ENET_RGMII_TD3  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_TX_CTL__RGMII_TX_CTL | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_ENET_REF_CLK__ENET_TX_CLK  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        /* pin 35 - 1 (PHY_AD2) on reset */
+        MX6Q_PAD_RGMII_RXC__GPIO_6_30       | MUX_PAD_CTRL(NO_PAD_CTRL),
+        /* pin 32 - 1 - (MODE0) all */
+        MX6Q_PAD_RGMII_RD0__GPIO_6_25       | MUX_PAD_CTRL(NO_PAD_CTRL),
+        /* pin 31 - 1 - (MODE1) all */
+        MX6Q_PAD_RGMII_RD1__GPIO_6_27       | MUX_PAD_CTRL(NO_PAD_CTRL),
+        /* pin 28 - 1 - (MODE2) all */
+        MX6Q_PAD_RGMII_RD2__GPIO_6_28       | MUX_PAD_CTRL(NO_PAD_CTRL),
+        /* pin 27 - 1 - (MODE3) all */
+        MX6Q_PAD_RGMII_RD3__GPIO_6_29       | MUX_PAD_CTRL(NO_PAD_CTRL),
+        /* pin 33 - 1 - (CLK125_EN) 125Mhz clockout enabled */
+        MX6Q_PAD_RGMII_RX_CTL__GPIO_6_24    | MUX_PAD_CTRL(NO_PAD_CTRL),
+        /* pin 42 PHY nRST */
+        MX6Q_PAD_EIM_D23__GPIO_3_23     | MUX_PAD_CTRL(NO_PAD_CTRL)
+    );
+
     gpio_direction_output(IMX_GPIO_NR(6, 24), 1, io_ops);
     /* Need delay 10ms according to KSZ9021 spec */
     udelay(1000 * 10);
     gpio_set_value(IMX_GPIO_NR(3, 23), 1);
 
-    ret = imx_iomux_v3_setup_multiple_pads(base, enet_pads2, ARRAY_SIZE(enet_pads2));
-    if (ret) {
-        return ret;
-    }
+    IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(
+        base,
+        MX6Q_PAD_RGMII_RXC__ENET_RGMII_RXC  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_RD0__ENET_RGMII_RD0  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_RD1__ENET_RGMII_RD1  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_RD2__ENET_RGMII_RD2  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_RD3__ENET_RGMII_RD3  | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_RGMII_RX_CTL__RGMII_RX_CTL | MUX_PAD_CTRL(ENET_PAD_CTRL),
+    );
 
 #else
 #error "unsupported platform"

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -174,6 +174,8 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
     gpio_direction_output(GPIO_NR_PHY_MODE1,     1, io_ops);
     gpio_direction_output(GPIO_NR_PHY_MODE2,     1, io_ops);
     gpio_direction_output(GPIO_NR_PHY_MODE3,     1, io_ops);
+    // enable 125MHz clock output
+    gpio_direction_output(GPIO_NR_PHY_CLK125_EN, 1, io_ops);
 
     // set pad configuration (after we have set well-defined GPIOs above)
     IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(
@@ -196,12 +198,6 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
         MX6Q_PAD_RGMII_RX_CTL__GPIO_6_24    | MUX_PAD_CTRL(NO_PAD_CTRL),
         MX6Q_PAD_EIM_D23__GPIO_3_23         | MUX_PAD_CTRL(NO_PAD_CTRL),
     );
-
-    /* ToDo: is there any reason why we can't set the GPIO for PHY CLK125_EN
-     * in IMX_IOMUX_V3_SETUP_MULTIPLE_PADS() above like every other pin?
-     */
-    // CLK125_EN is latched at reset, '1' will enable 125MHz Clock Output
-    gpio_direction_output(GPIO_NR_PHY_CLK125_EN, 1, io_ops);
 
     /* Need delay 10ms according to KSZ9021 spec */
     udelay(1000 * 10);

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -152,20 +152,34 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
 
 #elif defined(CONFIG_PLAT_IMX6)
 
-    gpio_direction_output(IMX_GPIO_NR(3, 23), 0, io_ops);
-    gpio_direction_output(IMX_GPIO_NR(6, 30), 1, io_ops);
-    gpio_direction_output(IMX_GPIO_NR(6, 25), 1, io_ops);
-    gpio_direction_output(IMX_GPIO_NR(6, 27), 1, io_ops);
-    gpio_direction_output(IMX_GPIO_NR(6, 28), 1, io_ops);
-    gpio_direction_output(IMX_GPIO_NR(6, 29), 1, io_ops);
-
 #define ENET_PAD_CTRL  (PAD_CTL_PKE | PAD_CTL_PUE | PAD_CTL_PUS_100K_UP | \
                         PAD_CTL_SPEED_MED | PAD_CTL_DSE_40ohm | PAD_CTL_HYS)
 
+
+/* PHY to GPIO mapping for strapping */
+#define GPIO_NR_PHY_NRST        IMX_GPIO_NR(3, 23) // EIM_D23      to PHY pin 42 nRST
+#define GPIO_NR_PHY_AD2         IMX_GPIO_NR(6, 30) // RGMII_RXC    to PHY pin 35 AD2
+#define GPIO_NR_PHY_MODE0       IMX_GPIO_NR(6, 25) // RGMII_RD0    to PHY pin 32 MODE0
+#define GPIO_NR_PHY_MODE1       IMX_GPIO_NR(6, 27) // RGMII_RD1    to PHY pin 31 MODE1
+#define GPIO_NR_PHY_MODE2       IMX_GPIO_NR(6, 28) // RGMII_RD2    to PHY pin 28 MODE2
+#define GPIO_NR_PHY_MODE3       IMX_GPIO_NR(6, 29) // RGMII_RD3    to PHY pin 27 MODE3
+#define GPIO_NR_PHY_CLK125_EN   IMX_GPIO_NR(6, 24) // RGMII_RX_CTL to PHY pin 33 CLK125_EN
+
+    // put PHY into reset
+    gpio_direction_output(GPIO_NR_PHY_NRST,      0, io_ops);
+    // PHYAD=b00100
+    gpio_direction_output(GPIO_NR_PHY_AD2,       1, io_ops);
+     // MODE=b1111 (RGMII Mode, 10/100/1000 speed, half/full duplex)
+    gpio_direction_output(GPIO_NR_PHY_MODE0,     1, io_ops);
+    gpio_direction_output(GPIO_NR_PHY_MODE1,     1, io_ops);
+    gpio_direction_output(GPIO_NR_PHY_MODE2,     1, io_ops);
+    gpio_direction_output(GPIO_NR_PHY_MODE3,     1, io_ops);
+
+    // set pad configuration (after we have set well-defined GPIOs above)
     IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(
         base,
         MX6Q_PAD_ENET_MDIO__ENET_MDIO       | MUX_PAD_CTRL(ENET_PAD_CTRL),
-        MX6Q_PAD_ENET_MDC__ENET_MDC     | MUX_PAD_CTRL(ENET_PAD_CTRL),
+        MX6Q_PAD_ENET_MDC__ENET_MDC         | MUX_PAD_CTRL(ENET_PAD_CTRL),
         MX6Q_PAD_RGMII_TXC__ENET_RGMII_TXC  | MUX_PAD_CTRL(ENET_PAD_CTRL),
         MX6Q_PAD_RGMII_TD0__ENET_RGMII_TD0  | MUX_PAD_CTRL(ENET_PAD_CTRL),
         MX6Q_PAD_RGMII_TD1__ENET_RGMII_TD1  | MUX_PAD_CTRL(ENET_PAD_CTRL),
@@ -173,27 +187,28 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
         MX6Q_PAD_RGMII_TD3__ENET_RGMII_TD3  | MUX_PAD_CTRL(ENET_PAD_CTRL),
         MX6Q_PAD_RGMII_TX_CTL__RGMII_TX_CTL | MUX_PAD_CTRL(ENET_PAD_CTRL),
         MX6Q_PAD_ENET_REF_CLK__ENET_TX_CLK  | MUX_PAD_CTRL(ENET_PAD_CTRL),
-        /* pin 35 - 1 (PHY_AD2) on reset */
+        // pad configuration as GPIO for PHY setup
         MX6Q_PAD_RGMII_RXC__GPIO_6_30       | MUX_PAD_CTRL(NO_PAD_CTRL),
-        /* pin 32 - 1 - (MODE0) all */
         MX6Q_PAD_RGMII_RD0__GPIO_6_25       | MUX_PAD_CTRL(NO_PAD_CTRL),
-        /* pin 31 - 1 - (MODE1) all */
         MX6Q_PAD_RGMII_RD1__GPIO_6_27       | MUX_PAD_CTRL(NO_PAD_CTRL),
-        /* pin 28 - 1 - (MODE2) all */
         MX6Q_PAD_RGMII_RD2__GPIO_6_28       | MUX_PAD_CTRL(NO_PAD_CTRL),
-        /* pin 27 - 1 - (MODE3) all */
         MX6Q_PAD_RGMII_RD3__GPIO_6_29       | MUX_PAD_CTRL(NO_PAD_CTRL),
-        /* pin 33 - 1 - (CLK125_EN) 125Mhz clockout enabled */
         MX6Q_PAD_RGMII_RX_CTL__GPIO_6_24    | MUX_PAD_CTRL(NO_PAD_CTRL),
-        /* pin 42 PHY nRST */
-        MX6Q_PAD_EIM_D23__GPIO_3_23     | MUX_PAD_CTRL(NO_PAD_CTRL)
+        MX6Q_PAD_EIM_D23__GPIO_3_23         | MUX_PAD_CTRL(NO_PAD_CTRL),
     );
 
-    gpio_direction_output(IMX_GPIO_NR(6, 24), 1, io_ops);
+    /* ToDo: is there any reason why we can't set the GPIO for PHY CLK125_EN
+     * in IMX_IOMUX_V3_SETUP_MULTIPLE_PADS() above like every other pin?
+     */
+    // CLK125_EN is latched at reset, '1' will enable 125MHz Clock Output
+    gpio_direction_output(GPIO_NR_PHY_CLK125_EN, 1, io_ops);
+
     /* Need delay 10ms according to KSZ9021 spec */
     udelay(1000 * 10);
-    gpio_set_value(IMX_GPIO_NR(3, 23), 1);
+    /* release PHY from reset */
+    gpio_set_value(GPIO_NR_PHY_NRST, 1);
 
+    /* reconfigure pins from GPIO for PHY setup to ethernet usage */
     IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(
         base,
         MX6Q_PAD_RGMII_RXC__ENET_RGMII_RXC  | MUX_PAD_CTRL(ENET_PAD_CTRL),

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -207,6 +207,8 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
     udelay(1000 * 10);
     /* release PHY from reset */
     gpio_set_value(GPIO_NR_PHY_NRST, 1);
+    /* KSZ9021 spec recommends to wait 100us before sending any commands */
+    udelay(100);
 
     /* reconfigure pins from GPIO for PHY setup to ethernet usage */
     IMX_IOMUX_V3_SETUP_MULTIPLE_PADS(

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -5,6 +5,7 @@
 /*
  * Copyright (C) 2010-2011 Freescale Semiconductor, Inc.
  * Copyright (C) 2018 NXP
+ * Copyright (C) 2020, HENSOLDT Cyber GmbH
  *
  * See file CREDITS for list of people who contributed to this
  * project.
@@ -174,39 +175,45 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
         return 1;
     }
 
-    if (config_set(CONFIG_PLAT_IMX8MQ_EVK)) {
-        ret = imx_iomux_v3_setup_multiple_pads(base, fec1_pads, ARRAY_SIZE(fec1_pads));
-        if (ret) {
-            return ret;
-        }
-        gpio_direction_output(IMX_GPIO_NR(1, 9), 0, io_ops);
-        udelay(500);
-        gpio_direction_output(IMX_GPIO_NR(1, 9), 1, io_ops);
+#if defined(CONFIG_PLAT_IMX8MQ_EVK)
 
-        uint32_t *gpr1 = base + 0x4;
-        // Change ENET_TX to use internal clocks and not the external clocks
-        *gpr1 = *gpr1 & ~(BIT(17) | BIT(13));
-    } else if (config_set(CONFIG_PLAT_IMX6)) {
-        gpio_direction_output(IMX_GPIO_NR(3, 23), 0, io_ops);
-        gpio_direction_output(IMX_GPIO_NR(6, 30), 1, io_ops);
-        gpio_direction_output(IMX_GPIO_NR(6, 25), 1, io_ops);
-        gpio_direction_output(IMX_GPIO_NR(6, 27), 1, io_ops);
-        gpio_direction_output(IMX_GPIO_NR(6, 28), 1, io_ops);
-        gpio_direction_output(IMX_GPIO_NR(6, 29), 1, io_ops);
-        ret = imx_iomux_v3_setup_multiple_pads(base, enet_pads1, ARRAY_SIZE(enet_pads1));
-        if (ret) {
-            return ret;
-        }
-        gpio_direction_output(IMX_GPIO_NR(6, 24), 1, io_ops);
-        /* Need delay 10ms according to KSZ9021 spec */
-        udelay(1000 * 10);
-        gpio_set_value(IMX_GPIO_NR(3, 23), 1);
-
-        ret = imx_iomux_v3_setup_multiple_pads(base, enet_pads2, ARRAY_SIZE(enet_pads2));
-        if (ret) {
-            return ret;
-        }
+    ret = imx_iomux_v3_setup_multiple_pads(base, fec1_pads, ARRAY_SIZE(fec1_pads));
+    if (ret) {
+        return ret;
     }
+    gpio_direction_output(IMX_GPIO_NR(1, 9), 0, io_ops);
+    udelay(500);
+    gpio_direction_output(IMX_GPIO_NR(1, 9), 1, io_ops);
+
+    uint32_t *gpr1 = base + 0x4;
+    // Change ENET_TX to use internal clocks and not the external clocks
+    *gpr1 = *gpr1 & ~(BIT(17) | BIT(13));
+
+#elif defined(CONFIG_PLAT_IMX6)
+
+    gpio_direction_output(IMX_GPIO_NR(3, 23), 0, io_ops);
+    gpio_direction_output(IMX_GPIO_NR(6, 30), 1, io_ops);
+    gpio_direction_output(IMX_GPIO_NR(6, 25), 1, io_ops);
+    gpio_direction_output(IMX_GPIO_NR(6, 27), 1, io_ops);
+    gpio_direction_output(IMX_GPIO_NR(6, 28), 1, io_ops);
+    gpio_direction_output(IMX_GPIO_NR(6, 29), 1, io_ops);
+    ret = imx_iomux_v3_setup_multiple_pads(base, enet_pads1, ARRAY_SIZE(enet_pads1));
+    if (ret) {
+        return ret;
+    }
+    gpio_direction_output(IMX_GPIO_NR(6, 24), 1, io_ops);
+    /* Need delay 10ms according to KSZ9021 spec */
+    udelay(1000 * 10);
+    gpio_set_value(IMX_GPIO_NR(3, 23), 1);
+
+    ret = imx_iomux_v3_setup_multiple_pads(base, enet_pads2, ARRAY_SIZE(enet_pads2));
+    if (ret) {
+        return ret;
+    }
+
+#else
+#error "unsupported platform"
+#endif
 
     if (unmapOnExit) {
         UNRESOURCE(&io_ops->io_mapper, IOMUXC, base);

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -32,22 +32,28 @@
 
 #include "common.h"
 #include "../io.h"
-#include "mx6x_pins.h"
-#include "imx8mq_pins.h"
 #include "miiphy.h"
 #include "micrel.h"
-#include "mx6qsabrelite.h"
-#include <utils/util.h>
+
 #include <platsupport/io.h>
 #include <stdio.h>
 
-#ifdef CONFIG_PLAT_IMX6
-#define IOMUXC_PADDR 0x020E0000
-#define IOMUXC_SIZE      0x4000
-#endif
-#ifdef CONFIG_PLAT_IMX8MQ_EVK
-#define IOMUXC_PADDR 0x30330000
-#define IOMUXC_SIZE      0x10000
+#include "mx6qsabrelite.h"
+
+#if defined(CONFIG_PLAT_IMX6)
+
+#include "mx6x_pins.h"
+
+#define IOMUXC_PADDR    0x020E0000
+#define IOMUXC_SIZE     0x4000
+
+#elif defined(CONFIG_PLAT_IMX8MQ_EVK)
+
+#include "imx8mq_pins.h"
+
+#define IOMUXC_PADDR    0x30330000
+#define IOMUXC_SIZE     0x10000
+
 #endif
 
 /*

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -110,6 +110,7 @@ int setup_iomux_enet(ps_io_ops_t *io_ops)
         unmapOnExit = 1;
     }
     if (!base) {
+        LOG_ERROR("base is NULL");
         return 1;
     }
 

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.c
@@ -32,19 +32,13 @@
 
 #include "common.h"
 #include "../io.h"
-#include "imx-regs.h"
-#include <errno.h>
-
-#include "gpio.h"
 #include "mx6x_pins.h"
 #include "imx8mq_pins.h"
 #include "miiphy.h"
 #include "micrel.h"
 #include "mx6qsabrelite.h"
-#include <assert.h>
 #include <utils/util.h>
 #include <platsupport/io.h>
-
 #include <stdio.h>
 
 #ifdef CONFIG_PLAT_IMX6

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.h
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.h
@@ -28,58 +28,13 @@
 
 #include "imx-regs.h"
 #include "gpio.h"
-#include <stdint.h>
-
-#define CONFIG_MII
 
 #define CONFIG_PHYLIB
+#ifdef CONFIG_PLAT_IMX6SX
+#define CONFIG_PHY_ATHEROS
+#else
 #define CONFIG_PHY_MICREL
-
-/* Command definition */
-#include "config.h"
-
-typedef uint64_t iomux_v3_cfg_t;
-
-#define MUX_CTRL_OFS_SHIFT  0
-#define MUX_CTRL_OFS_MASK   ((iomux_v3_cfg_t)0xfff << MUX_CTRL_OFS_SHIFT)
-#define MUX_PAD_CTRL_OFS_SHIFT  12
-#define MUX_PAD_CTRL_OFS_MASK   ((iomux_v3_cfg_t)0xfff << \
-    MUX_PAD_CTRL_OFS_SHIFT)
-#define MUX_SEL_INPUT_OFS_SHIFT 24
-#define MUX_SEL_INPUT_OFS_MASK  ((iomux_v3_cfg_t)0xfff << \
-    MUX_SEL_INPUT_OFS_SHIFT)
-
-#define MUX_MODE_SHIFT      36
-#define MUX_MODE_MASK       ((iomux_v3_cfg_t)0x3f << MUX_MODE_SHIFT)
-#define MUX_PAD_CTRL_SHIFT  42
-#define MUX_PAD_CTRL_MASK   ((iomux_v3_cfg_t)0x3ffff << MUX_PAD_CTRL_SHIFT)
-#define MUX_SEL_INPUT_SHIFT 60
-#define MUX_SEL_INPUT_MASK  ((iomux_v3_cfg_t)0xf << MUX_SEL_INPUT_SHIFT)
-
-#define MUX_PAD_CTRL(x)     ((iomux_v3_cfg_t)(x) << MUX_PAD_CTRL_SHIFT)
-
-#define IOMUX_PAD(pad_ctrl_ofs, mux_ctrl_ofs, mux_mode, sel_input_ofs,  \
-        sel_input, pad_ctrl)                    \
-    (((iomux_v3_cfg_t)(mux_ctrl_ofs) << MUX_CTRL_OFS_SHIFT)     |   \
-    ((iomux_v3_cfg_t)(mux_mode)      << MUX_MODE_SHIFT)         |   \
-    ((iomux_v3_cfg_t)(pad_ctrl_ofs)  << MUX_PAD_CTRL_OFS_SHIFT) |   \
-    ((iomux_v3_cfg_t)(pad_ctrl)      << MUX_PAD_CTRL_SHIFT)     |   \
-    ((iomux_v3_cfg_t)(sel_input_ofs) << MUX_SEL_INPUT_OFS_SHIFT)|   \
-    ((iomux_v3_cfg_t)(sel_input)     << MUX_SEL_INPUT_SHIFT))
-
-#define NO_PAD_CTRL     (BIT(17))
-#define GPIO_PIN_MASK       0x1f
-#define GPIO_PORT_SHIFT     5
-#define GPIO_PORT_MASK      (0x7 << GPIO_PORT_SHIFT)
-#define GPIO_PORTA      (0 << GPIO_PORT_SHIFT)
-#define GPIO_PORTB      (BIT(GPIO_PORT_SHIFT))
-#define GPIO_PORTC      (2 << GPIO_PORT_SHIFT)
-#define GPIO_PORTD      (3 << GPIO_PORT_SHIFT)
-#define GPIO_PORTE      (4 << GPIO_PORT_SHIFT)
-#define GPIO_PORTF      (5 << GPIO_PORT_SHIFT)
-
-#define MUX_CONFIG_SION     (BIT(4))
-
+#endif
 
 int
 setup_iomux_enet(

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.h
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.h
@@ -26,54 +26,18 @@
 
 #pragma once
 
-#define CONFIG_MX6
-#define CONFIG_MX6Q
-
-#define CONFIG_MACH_TYPE    3769
-
 #include "imx-regs.h"
 #include "gpio.h"
-
 #include <stdint.h>
 
-#define CONFIG_BOARD_EARLY_INIT_F
-#define CONFIG_MISC_INIT_R
-#define CONFIG_MXC_GPIO
-
-#define CONFIG_FEC_MXC
 #define CONFIG_MII
-#define IMX_FEC_BASE            ENET_BASE_ADDR
-#define CONFIG_FEC_XCV_TYPE     RGMII
-#define CONFIG_ETHPRIME         "FEC"
-#define CONFIG_FEC_MXC_PHYMASK      (0xf << 4)  /* scan phy 4,5,6,7 */
+
 #define CONFIG_PHYLIB
 #define CONFIG_PHY_MICREL
-#define CONFIG_PHY_MICREL_KSZ9021
 
 /* Command definition */
 #include "config.h"
 
-#define CONFIG_MX6
-#define CONFIG_MX6Q
-
-#include "imx-regs.h"
-
-#define CONFIG_BOARD_EARLY_INIT_F
-#define CONFIG_MXC_GPIO
-
-#define CONFIG_MXC_UART
-#define CONFIG_FEC_MXC
-#define CONFIG_MII
-#define IMX_FEC_BASE            ENET_BASE_ADDR
-#define CONFIG_FEC_XCV_TYPE     RGMII
-#define CONFIG_ETHPRIME         "FEC"
-#define CONFIG_FEC_MXC_PHYADDR      1
-
-#define CONFIG_PHYLIB
-#define CONFIG_PHY_ATHEROS
-
-/* Command definition */
-#include "config.h"
 typedef uint64_t iomux_v3_cfg_t;
 
 #define MUX_CTRL_OFS_SHIFT  0

--- a/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.h
+++ b/libethdrivers/src/plat/imx6/uboot/mx6qsabrelite.h
@@ -4,6 +4,7 @@
 
 /*
  * Copyright (C) 2010-2011 Freescale Semiconductor, Inc.
+ * Copyright (C) 2020, HENSOLDT Cyber GmbH
  *
  * Configuration settings for the Freescale i.MX6Q Sabre Lite board.
  *
@@ -115,3 +116,7 @@ typedef uint64_t iomux_v3_cfg_t;
 
 #define MUX_CONFIG_SION     (BIT(4))
 
+
+int
+setup_iomux_enet(
+    ps_io_ops_t *io_ops);

--- a/libethdrivers/src/plat/imx6/uboot/mx6x_pins.h
+++ b/libethdrivers/src/plat/imx6/uboot/mx6x_pins.h
@@ -4,6 +4,7 @@
 
 /*
  * Copyright (C) 2011 Freescale Semiconductor, Inc. All Rights Reserved.
+ * Copyright (C) 2020, HENSOLDT Cyber GmbH
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,34 +26,7 @@
 
 #pragma once
 
-#include "mx6qsabrelite.h"
-
-/* Use to set PAD control */
-#define PAD_CTL_HYS		(BIT(16))
-#define PAD_CTL_PUS_100K_DOWN	(0 << 14)
-#define PAD_CTL_PUS_47K_UP	(BIT(14))
-#define PAD_CTL_PUS_100K_UP	(2 << 14)
-#define PAD_CTL_PUS_22K_UP	(3 << 14)
-
-#define PAD_CTL_PUE		(BIT(13))
-#define PAD_CTL_PKE		(BIT(12))
-#define PAD_CTL_ODE		(BIT(11))
-#define PAD_CTL_SPEED_LOW	(BIT(6))
-#define PAD_CTL_SPEED_MED	(2 << 6)
-#define PAD_CTL_SPEED_HIGH	(3 << 6)
-#define PAD_CTL_DSE_DISABLE	(0 << 3)
-#define PAD_CTL_DSE_240ohm	(BIT(3))
-#define PAD_CTL_DSE_120ohm	(2 << 3)
-#define PAD_CTL_DSE_80ohm	(3 << 3)
-#define PAD_CTL_DSE_60ohm	(4 << 3)
-#define PAD_CTL_DSE_48ohm	(5 << 3)
-#define PAD_CTL_DSE_40ohm	(6 << 3)
-#define PAD_CTL_DSE_34ohm	(7 << 3)
-#define PAD_CTL_SRE_FAST	(BIT(0))
-#define PAD_CTL_SRE_SLOW	(0 << 0)
-
-#define NO_MUX_I                0
-#define NO_PAD_I                0
+#include "mx6_pins.h"
 
 enum {
 	MX6Q_PAD_SD2_DAT1__USDHC2_DAT1		= IOMUX_PAD(0x0360, 0x004C, 0, 0x0000, 0, 0),

--- a/libethdrivers/src/plat/imx6/uboot/mxc_gpio.c
+++ b/libethdrivers/src/plat/imx6/uboot/mxc_gpio.c
@@ -9,6 +9,8 @@
  * Copyright (C) 2011
  * Stefano Babic, DENX Software Engineering, <sbabic@denx.de>
  *
+ * Copyright (C) 2020, HENSOLDT Cyber GmbH
+ *
  * See file CREDITS for list of people who contributed to this
  * project.
  *
@@ -91,6 +93,7 @@ static int mxc_gpio_direction(unsigned int gpio,
     uint32_t l;
 
     if (port >= ARRAY_SIZE(gpio_ports)) {
+        LOG_ERROR("invalid GPIO port %u for pin %u",port, gpio);
         return -1;
     }
 
@@ -100,7 +103,7 @@ static int mxc_gpio_direction(unsigned int gpio,
         uintptr_t gpio_phys = (uintptr_t)gpio_paddr[port];
         gpio_ports[port] = (unsigned long)ps_io_map(&io_ops->io_mapper, gpio_phys, GPIO_SIZE, 0, PS_MEM_NORMAL);
         if (gpio_ports[port] == 0) {
-            LOG_ERROR("Warning: No map for GPIO %d. Assuming that it is already configured\n", port);
+            LOG_ERROR("No mapping for GPIO port %u of pin %u. Assuming it's already configured", port, gpio);
             return 0;
         }
     }
@@ -127,6 +130,7 @@ int gpio_set_value(unsigned gpio, int value)
     uint32_t l;
 
     if (port >= ARRAY_SIZE(gpio_ports)) {
+        LOG_ERROR("invalid GPIO port %u for pin %u",port, gpio);
         return -1;
     }
 
@@ -152,6 +156,7 @@ int gpio_get_value(unsigned gpio)
     uint32_t val;
 
     if (port >= ARRAY_SIZE(gpio_ports)) {
+        LOG_ERROR("invalid GPIO port %u for pin %u",port, gpio);
         return -1;
     }
 
@@ -168,6 +173,7 @@ int gpio_request(unsigned gpio, const char *label)
 {
     unsigned int port = GPIO_TO_PORT(gpio);
     if (port >= ARRAY_SIZE(gpio_ports)) {
+        LOG_ERROR("invalid GPIO port %u for pin %u",port, gpio);
         return -1;
     }
     return 0;
@@ -188,6 +194,7 @@ int gpio_direction_output(unsigned gpio, int value, ps_io_ops_t *io_ops)
     int ret = mxc_gpio_direction(gpio, MXC_GPIO_DIRECTION_OUT, io_ops);
 
     if (ret < 0) {
+        LOG_ERROR("Could not set output direction for pin %u, code %u", gpio, ret);
         return ret;
     }
 

--- a/libethdrivers/src/plat/imx6/uboot/phy.c
+++ b/libethdrivers/src/plat/imx6/uboot/phy.c
@@ -545,7 +545,10 @@ static struct phy_device *create_phy_by_mask(struct mii_dev *bus,
 		int addr = ffs(phy_mask) - 1;
 		int r = get_phy_id(bus, addr, devad, &phy_id);
 		if (r < 0)
-			return (void*)r;
+		{
+			LOG_ERROR("Failed to get PHY ID, code %d", r);
+			return NULL;
+		}
 		/* If the PHY ID is mostly f's, we didn't find anything */
 		if ((phy_id & 0x1fffffff) != 0x1fffffff)
 			return phy_device_create(bus, addr, phy_id, interface);
@@ -583,8 +586,6 @@ static struct phy_device *get_phy_device_by_mask(struct mii_dev *bus,
 	/* Otherwise we have to try Clause 45 */
 	for (i = 0; i < 5; i++) {
 		phydev = create_phy_by_mask(bus, phy_mask, i ? i : MDIO_DEVAD_NONE, interface);
-		if ((unsigned long)phydev >= (unsigned long)-4096)
-			return NULL;
 		if (phydev)
 			return phydev;
 	}

--- a/libethdrivers/src/plat/imx6/uboot/phy.c
+++ b/libethdrivers/src/plat/imx6/uboot/phy.c
@@ -230,19 +230,24 @@ int genphy_update_link(struct phy_device *phydev)
 	 * we don't need to wait for autoneg again
 	 */
 	if (phydev->link && mii_reg & BMSR_LSTATUS)
+    {
+        LOG_INFO("link already established");
 		return 0;
+    }
 
 	if ((mii_reg & BMSR_ANEGCAPABLE) && !(mii_reg & BMSR_ANEGCOMPLETE)) {
 		int i = 0;
 
-		printf("%s Waiting for PHY auto negotiation to complete", phydev->dev->name);
+		LOG_INFO(
+            "waiting for auto negotiation to complete on phy %d, '%s'",
+            phydev->addr, phydev->dev->name);
         fflush(stdout);
 		while (!(mii_reg & BMSR_ANEGCOMPLETE)) {
 			/*
 			 * Timeout reached ?
 			 */
 			if (i > PHY_ANEG_TIMEOUT) {
-				printf(" TIMEOUT !\n");
+				LOG_ERROR("auto negotiation timeout");
 				phydev->link = 0;
 				return 0;
 			}
@@ -255,7 +260,8 @@ int genphy_update_link(struct phy_device *phydev)
 			udelay(1000);	/* 1 ms */
 			mii_reg = phy_read(phydev, MDIO_DEVAD_NONE, MII_BMSR);
 		}
-		printf(" done\n");
+		LOG_INFO("auto negotiation complete on phy %d, '%s'",
+                 phydev->addr, phydev->dev->name);
 		phydev->link = 1;
 	} else {
 		/* Read the link a second time to clear the latched state */

--- a/libplatsupport/plat_include/imx6/platsupport/plat/clock.h
+++ b/libplatsupport/plat_include/imx6/platsupport/plat/clock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -38,6 +39,7 @@ enum clk_id {
 enum clock_gate {
     /* -- CCGR0 -- */
     /* -- CCGR1 -- */
+    enet_clock   = CLK_GATE(1, 5),
     /* -- CCGR2 -- */
     ocotp_ctrl   = CLK_GATE(2, 6),
     i2c3_serial  = CLK_GATE(2, 5),

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -25,9 +25,9 @@
 #define PLL_ENABLE              BIT(13)
 #define PLL_PWR_DOWN            BIT(12)
 
-/* PLL_ARM */
-#define PLL_ARM_DIV_MASK  0x7F
-#define PLL_ARM_ENABLE    BIT(13)
+/* PLL_ARM (PLL1), up to 1.3 GHz */
+#define PLL_ARM_DIV_MASK        0x7F
+#define PLL_ARM_GET_DIV(x)      ((x) & PLL_ARM_DIV_MASK)
 
 /* PLL_SYS (also called PLL2 or PLL_528) runs at a fixed multiplier 22 based
  * on the 24 MHz oscillator to create a 528 MHz a reference clock
@@ -215,34 +215,80 @@ static int change_pll(alg_sct_t* pll, uint32_t div_mask, uint32_t div)
 
 static freq_t _arm_get_freq(clk_t *clk)
 {
-    uint32_t div;
-    uint32_t fout, fin;
-    div = clk_regs.alg->pll_arm.val;
-    div &= PLL_ARM_DIV_MASK;
-    fin = clk_get_freq(clk->parent);
-    fout = fin * div / 2;
-    return fout;
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
+        return 0;
+    }
+
+    uint32_t v = clk_regs.alg->pll_enet.val;
+
+    /* clock output enabled? */
+    if (!(v & PLL_ENABLE))
+    {
+        /* we should never be here, because we are running on the ARM core */
+        return 0;
+    }
+
+    if (v & PLL_BYPASS)
+    {
+        /* bypass on
+         * 0x0 source is 24MHz oscillator
+         * 0x1 source is CLK1_N/CLK1_P
+         * 0x2 source is CLK2_N/CLK2_P
+         * 0x3 source is CLK1_N/CLK1_P XOR CLK2_N/CLK2_P
+         */
+        unsigned int src = PLL_GET_BYPASS_SRC(v);
+        switch (src) {
+            case 0: return 24 * MHZ;
+            default: break;
+        }
+        LOG_ERROR("can determine frequency for bypass sources %u", src);
+        return 0;
+    }
+
+    /* PLL enabled, but powered down? */
+    if (v & PLL_PWR_DOWN)
+    {
+        /* we should never be here, because we are running on the ARM core */
+        return 0;
+    }
+
+    /* valid divider range 54 to 108, F_out = F_in * div_select / 2 */
+    unsigned int div = PLL_ARM_GET_DIV(v);
+    if ((div < 54) || (div > 108))
+    {
+        LOG_ERROR("PLL_ARM divider out of valid range 54-108: %u", div);
+    }
+    freq_t f_in = clk_get_freq(clk->parent);
+    return f_in * div / 2;
 }
 
 static freq_t _arm_set_freq(clk_t *clk, freq_t hz)
 {
-    uint32_t div;
-    uint32_t fin;
-    uint32_t v;
+    LOG_INFO("clock '%s': switch from %u Mhz to %llu (%u Mhz)",
+             clk->name, (int)(clk_get_freq(clk) / MHZ), hz, (int)(hz/MHZ));
 
-    fin = clk_get_freq(clk->parent);
-    div = 2 * hz / fin;
-    div = INRANGE(54, div, 108);
-    /* bypass on during clock manipulation */
-    clk_regs.alg->pll_arm.set = PLL_BYPASS;
-    /* Set the divisor */
-    v = clk_regs.alg->pll_arm.val & ~(PLL_ARM_DIV_MASK);
-    v |= div;
-    clk_regs.alg->pll_arm.val = v;
-    /* wait for lock */
-    while (!(clk_regs.alg->pll_arm.val & PLL_LOCK));
-    /* bypass off */
-    clk_regs.alg->pll_arm.clr = PLL_BYPASS;
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
+        return 0;
+    }
+
+    alg_sct_t* pll = &clk_regs.alg->pll_arm;
+
+    freq_t fin = clk_get_freq(clk->parent);
+    unsigned int div = 2 * hz / fin;
+    if ((div < 54) || (div > 108))
+    {
+        LOG_ERROR("PLL_ARM divider out of valid range 54-108: %u", div);
+        return 0;
+    }
+
+    int ret = change_pll(pll, PLL_ARM_DIV_MASK, div);
+    if (0 != ret) {
+        LOG_ERROR("waiting for PLL_ARM lock aborted, code %d", ret);
+        return 0;
+    }
+
     return clk_get_freq(clk);
 }
 

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -71,15 +71,16 @@
 #define CLKGATE_MODE_ON_ALL     0x3
 #define CLKGATE_MODE_MASK       0x3
 
-#define CLKO1_SRC_AHB       (0xBU << 0)
-#define CLKO1_SRC_IPG       (0xCU << 0)
-#define CLKO1_SRC_MASK      (0xFU << 0)
-#define CLKO1_ENABLE        (1U << 7)
+/* CCM Clock Output Source (CCM_CCOSR) */
+#define CLKO1_SRC_AHB       0xBU
+#define CLKO1_SRC_IPG       0xCU
+#define CLKO1_SRC_MASK      0xFU /* bit 0-3 */
+#define CLKO1_ENABLE        BIT(7)
+#define CLKO_SEL            BIT(8) /* select CCM_CLKO1 or CCM_CLKO2 */
+#define CLKO2_SRC_MMDC_CH0  (0U << 16)
+#define CLKO2_SRC_MASK      (0x1FU << 16) /* bit 16-20 */
+#define CLKO2_ENABLE        BIT(24)
 
-#define CLKO2_SRC_MMDC_CH0  (0U << 21)
-#define CLKO2_SRC_MASK      (0x1FU << 16)
-#define CLKO2_ENABLE        (1U << 24)
-#define CLKO_SEL            (1U << 8)
 
 typedef volatile struct {
     uint32_t ccr;      /* 0x000 */

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -50,10 +50,6 @@
 #define PLL2_SS_EN              BIT(15)
 #define PLL2_SS_STEP(x)         ((x) <<  0)
 
-#define PLL_CLKGATE BIT(31)
-#define PLL_STABLE  BIT(30)
-#define PLL_FRAC(x) ((x) << 24)
-
 #define CLKGATE_OFF    0x0
 #define CLKGATE_ON_RUN 0x2
 #define CLKGATE_ON_ALL 0x3

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -45,11 +45,17 @@
 #define PLL_ENET_DIV_MASK 0x3
 #define PLL_ENET_ENABLE   BIT(13)
 
-/* USB */
-#define PLL_USB_DIV_MASK  0x3
-#define PLL_EN_USB_CLKS   BIT(6)
-#define PLL_USB_ENABLE    BIT(13)
-#define PLL_USB_POWER     BIT(12)
+/* PLL_USB. There is PLL3 (USB1_PLL or 480 PLL) that runs at a fixed multiplier
+ * 20 and based on the 24 MHz oscillator creates a 480 MHz reference clock
+ * (24 MHz * 20 = 480 MHz). It is used for USB0 PHY (OTG PHY) and also to create
+ * clocks for UART, CAN, other serial interfaces and audio interfaces.
+ * There is also 480_PLL2 (USB2_PLL), which provides clock exclusively to
+ * USB2 PHY (also known as HOST PHY) that also runs at a fixed multiplier of 20
+ * to generate a 480 MHz clock.
+ */
+#define PLL_USB_ENABLE_CLKS     BIT(6)
+#define PLL_USB_DIV_MASK        0x3
+#define PLL_USB_GET_DIV(x)      ((x) & PLL_USB_DIV_MASK)
 
 
 #define CLKGATE_OFF    0x0
@@ -625,22 +631,59 @@ static struct clock ipg_clk = { CLK_OPS(IPG, ipg, NULL) };
 
 static freq_t _usb_get_freq(clk_t *clk)
 {
-    volatile alg_sct_t *pll_usb;
-    pll_usb = clk_regs.alg->pll_usb;
-    if (clk->id == CLK_USB2) {
-        pll_usb++;
-    } else if (clk->id != CLK_USB1) {
-        assert(0);
+    unsigned int idx;
+    switch (clk->id) {
+        case CLK_USB1: idx = 0; break;
+        case CLK_USB2: idx = 1; break;
+        default:
+            LOG_ERROR("invalid USB clock ID: %u", clk->id);
+            return 0;
+    }
+
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
         return 0;
     }
-    if (pll_usb->val & ~PLL_BYPASS) {
-        if (pll_usb->val & (PLL_USB_ENABLE | PLL_USB_POWER | PLL_EN_USB_CLKS)) {
-            uint32_t div = (pll_usb->val & PLL_USB_DIV_MASK) ? 22 : 20;
-            return clk_get_freq(clk->parent) * div;
-        }
+
+    uint32_t v = clk_regs.alg->pll_usb[idx].val;
+
+    /* clock output enabled? */
+    if (!(v & PLL_ENABLE))
+    {
+        return 0;
     }
-    /* Not enabled or in bypass mode...
-     * We should only be in bypass when changing Fout */
+
+    if (v & PLL_BYPASS)
+    {
+        /* bypass on
+         * 0x0 source is 24MHz oscillator
+         * 0x1 source is CLK1_N/CLK1_P
+         * 0x2 source is CLK2_N/CLK2_P
+         * 0x3 source is CLK1_N/CLK1_P XOR CLK2_N/CLK2_P
+         */
+        unsigned int src = PLL_GET_BYPASS_SRC(v);
+        switch (src) {
+            case 0: return 24 * MHZ;
+            default: break;
+        }
+        LOG_ERROR("can determine frequency for bypass sources %u", src);
+        return 0;
+    }
+
+    /* PLL enabled, but powered down? */
+    if (v & PLL_PWR_DOWN)
+    {
+        return 0;
+    }
+
+    freq_t f_parent = clk_get_freq(clk->parent);
+    unsigned int div = PLL_USB_GET_DIV(v);
+    switch (div) {
+        case 0: return  f_parent * 20;
+        case 1: return  f_parent * 22;
+        default: break;
+    }
+    LOG_ERROR("unsupported USB PLL divider %u", v);
     return 0;
 }
 
@@ -657,26 +700,30 @@ static void _usb_recal(clk_t *clk UNUSED)
 
 static clk_t *_usb_init(clk_t *clk)
 {
-    volatile alg_sct_t *pll_usb;
     if (clk->parent == NULL) {
         clk_t *parent = clk_get_clock(clk_get_clock_sys(clk), CLK_MASTER);
         clk_register_child(parent, clk);
         clk->priv = (void *)&clk_regs;
     }
-    if (clk_regs.alg == NULL) {
-        ZF_LOGF("clk_regs.alg is NULL: Clocks likely not initialised properly");
+
+    unsigned int idx;
+    switch (clk->id) {
+        case CLK_USB1: idx = 0; break;
+        case CLK_USB2: idx = 1; break;
+        default:
+            LOG_ERROR("invalid USB clock ID: %u", clk->id);
+            return NULL;
+    }
+
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
         return NULL;
     }
+    alg_sct_t *pll = &clk_regs.alg->pll_usb[idx];
+
     /* While we are here, gate the clocks */
-    pll_usb = clk_regs.alg->pll_usb;
-    if (clk->id == CLK_USB2) {
-        pll_usb++;
-    } else if (clk->id != CLK_USB1) {
-        assert(0);
-        return NULL;
-    }
-    pll_usb->clr = PLL_BYPASS;
-    pll_usb->set = PLL_USB_ENABLE | PLL_USB_POWER | PLL_EN_USB_CLKS;
+    pll->clr = PLL_BYPASS;
+    pll->set = PLL_ENABLE | PLL_PWR_DOWN | PLL_USB_ENABLE_CLKS;
     clk_gate_enable(clk_get_clock_sys(clk), usboh3, CLKGATE_ON);
     return clk;
 }

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -25,9 +25,21 @@
 #define PLL_ENABLE              BIT(13)
 #define PLL_PWR_DOWN            BIT(12)
 
-/* SYS PLL */
+/* PLL_ARM */
 #define PLL_ARM_DIV_MASK  0x7F
 #define PLL_ARM_ENABLE    BIT(13)
+
+/* PLL_SYS (also called PLL2 or PLL_528) runs at a fixed multiplier 22 based
+ * on the 24 MHz oscillator to create a 528 MHz a reference clock
+ * (24 MHz * 22 = 528 MHz). Other values than 22 are not supposed to be used.
+ */
+#define PLL_SYS_DIV_MASK        BIT(0)
+#define PLL_SYS_GET_DIV(x)      ((x) & PLL_SYS_DIV_MASK)
+
+/* PLL_SYS spread spectrum control (CCM_ANALOG_PLL_SYS_SS) */
+#define PLL_SYS_SS_STOP(x)      (((x) & 0xffff) << 16)
+#define PLL_SYS_SS_EN           BIT(15)
+#define PLL_SYS_SS_STEP(x)      ((x) & 0x7fff)
 
 /* ENET PLL */
 #define PLL_ENET_DIV_MASK 0x3
@@ -39,19 +51,6 @@
 #define PLL_USB_ENABLE    BIT(13)
 #define PLL_USB_POWER     BIT(12)
 
-/* Also known as PLL_SYS */
-#define PLL2_PADDR 0x020C8030
-
-#define PLL2_CTRL_LOCK          BIT(31)
-#define PLL2_CTRL_PDFOFFSET_EN  BIT(18)
-#define PLL2_CTRL_BYPASS        BIT(16)
-#define PLL2_CTRL_BYPASS_SRC(x) ((x) << 14)
-#define PLL2_CTRL_ENABLE        BIT(13)
-#define PLL2_CTRL_PWR_DOWN      BIT(12)
-#define PLL2_CTRL_DIVSEL        BIT(0)
-#define PLL2_SS_STOP(x)         ((x) << 16)
-#define PLL2_SS_EN              BIT(15)
-#define PLL2_SS_STEP(x)         ((x) <<  0)
 
 #define CLKGATE_OFF    0x0
 #define CLKGATE_ON_RUN 0x2
@@ -169,20 +168,43 @@ static struct {
     ccm_alg_regs_t *alg;
 } clk_regs = { .ccm = NULL, .alg = NULL};
 
-struct pll2_regs {
-    uint32_t ctrl;
-    uint32_t ctrl_s;
-    uint32_t ctrl_c;
-    uint32_t ctrl_t;
-    uint32_t ss;
-    uint32_t res0[3];
-    uint32_t num;
-    uint32_t res1[3];
-    uint32_t denom;
-    uint32_t res2[3];
-};
-
 static struct clock master_clk = { CLK_OPS_DEFAULT(MASTER) };
+
+static int change_pll(alg_sct_t* pll, uint32_t div_mask, uint32_t div)
+{
+    /* div can't exceed the mask */
+    assert(0 == (div & (~div_mask)));
+
+    /* bypass on during clock manipulation */
+    pll->set = PLL_BYPASS;
+    /* power down the PLL */
+    pll->set = PLL_PWR_DOWN;
+    /* set the divisor */
+    pll->clr = div_mask;
+    pll->set = div;
+    /* power up the PLL */
+    pll->clr = PLL_PWR_DOWN;
+
+    /* wait for PLL to be stable, stop after a bit over 65 million loops */
+    unsigned int loop_cnt = 0x4000000;
+    for(;;) {
+        if (pll->val & PLL_LOCK) {
+            break;
+        }
+
+        if (0 == loop_cnt--) {
+            LOG_ERROR("waiting for PLL_LOCK aborted");
+            return -1;
+        }
+    }
+
+    /* bypass off */
+    pll-> clr = PLL_BYPASS;
+    /* ensure PLL output is enabled */
+    pll->set = PLL_ENABLE;
+
+    return 0;
+}
 
 
 /*
@@ -325,57 +347,124 @@ static struct clock enet_clk = { CLK_OPS(ENET, enet, NULL) };
 
 /*
  *------------------------------------------------------------------------------
- * PLL2_CLK
+ * PLL_SYS
  *------------------------------------------------------------------------------
  */
 
-static freq_t _pll2_get_freq(clk_t *clk)
+static freq_t _pll_sys_get_freq(clk_t *clk)
 {
-    uint32_t p, s;
-    struct pll2_regs *regs;
-    regs = (struct pll2_regs *)((uint32_t)clk_regs.alg + (PLL2_PADDR & 0xfff));
-    assert((regs->ctrl & PLL2_CTRL_LOCK) != 0);
-    assert((regs->ctrl & PLL2_CTRL_BYPASS) == 0);
-    assert((regs->ctrl & PLL2_CTRL_PWR_DOWN) == 0);
-    /* pdf offset? */
-
-    p = clk_get_freq(clk->parent);
-    if (regs->ctrl & PLL2_CTRL_DIVSEL) {
-        s = 22;
-    } else {
-        s = 20;
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
+        return 0;
     }
-    return p * s;
+
+    uint32_t v = clk_regs.alg->pll_sys.val;
+
+    /* clock output enabled? */
+    if (!(v & PLL_ENABLE))
+    {
+        return 0;
+    }
+
+    if (v & PLL_BYPASS)
+    {
+        /* bypass on
+         * 0x0 source is 24MHz oscillator
+         * 0x1 source is CLK1_N/CLK1_P
+         * 0x2 source is CLK2_N/CLK2_P
+         * 0x3 source is CLK1_N/CLK1_P XOR CLK2_N/CLK2_P
+         */
+        unsigned int src = PLL_GET_BYPASS_SRC(v);
+        switch (src) {
+            case 0: return 24 * MHZ;
+            default: break;
+        }
+        LOG_ERROR("can determine frequency for bypass sources %u", src);
+        return 0;
+    }
+
+    /* PLL enabled, but powered down? */
+    if (v & PLL_PWR_DOWN)
+    {
+        return 0;
+    }
+
+    freq_t f_parent = clk_get_freq(clk->parent);
+    unsigned int div = PLL_SYS_GET_DIV(v);
+    switch (div) {
+        case 0: return  f_parent * 20;
+        case 1: return  f_parent * 22;
+        default: break;
+    }
+    LOG_ERROR("unsupported PLL_SYS divisor %u", div);
+    return 0;
 }
 
-static freq_t _pll2_set_freq(clk_t *clk, freq_t hz)
+static freq_t _pll_sys_set_freq(clk_t *clk, freq_t hz)
 {
-    uint32_t s;
-    if (clk_regs.alg == NULL) {
-        return clk_get_freq(clk);
+    LOG_INFO("clock '%s': switch from %u Mhz to %llu (%u Mhz)",
+             clk->name, (int)(clk_get_freq(clk) / MHZ), hz, (int)(hz/MHZ));
+
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
+        return 0;
     }
-    s = hz / clk_get_freq(clk->parent);
-    (void)s; /* TODO implement */
-    assert(hz == 528 * MHZ);
+
+    alg_sct_t* pll = &clk_regs.alg->pll_sys;
+
+    if (24 * MHZ == hz)
+    {
+        /* bypass PLL and use 24 MHz oscillator */
+        pll->set = PLL_BYPASS;
+        pll->set = PLL_PWR_DOWN;
+        pll->clr = PLL_ENET_DIV_MASK;
+        pll->set = PLL_ENABLE;
+    }
+    else
+    {
+        uint32_t div;
+        switch (hz)
+        {
+            case 480 * MHZ: div = 0; break; // 480 MHz = 20 * 24 MHz
+            case 528 * MHZ: div = 1; break; // 528 MHz = 22 * 24 MHz
+            default:
+                LOG_ERROR("unsupported PLL_SYS clock frequency %llu", hz);
+                return 0;
+        }
+
+        int ret = change_pll(pll, PLL_SYS_DIV_MASK, div);
+        if (0 != ret) {
+            LOG_ERROR("PLL_SYS change failed, code %d", ret);
+            return 0;
+        }
+    }
+
     return clk_get_freq(clk);
 }
 
-static void _pll2_recal(clk_t *clk UNUSED)
+static void _pll_sys_recal(clk_t *clk UNUSED)
 {
+    LOG_ERROR("PLL_SYS recal is not supported");
     assert(0);
 }
 
-static clk_t *_pll2_init(clk_t *clk)
+static clk_t *_pll_sys_init(clk_t *clk)
 {
     if (clk->parent == NULL) {
         clk_t *parent = clk_get_clock(clk_get_clock_sys(clk), CLK_MASTER);
         clk_register_child(parent, clk);
         clk->priv = (void *)&clk_regs;
     }
+
+    // After a reset, the system PLL is not active and the clock signal comes
+    // from the 24 MHz oscillator. We do reconfigure anything here, enabling
+    // the 528 MHz PLL must be done manually somewhere. Note that if U-Boot is
+    // used, it may have done this already.
+
     return clk;
 }
 
-static struct clock pll2_clk = { CLK_OPS(PLL2, pll2, NULL) };
+static struct clock pll_sys_clk = { CLK_OPS(PLL2, pll_sys, NULL) };
 
 
 /*
@@ -678,7 +767,7 @@ void clk_print_clock_tree(clock_sys_t *sys)
 
 clk_t *ps_clocks[] = {
     [CLK_MASTER]   = &master_clk,
-    [CLK_PLL2  ]   = &pll2_clk,
+    [CLK_PLL2]     = &pll_sys_clk,
     [CLK_MMDC_CH0] = &mmdc_ch0_clk,
     [CLK_AHB]      = &ahb_clk,
     [CLK_IPG]      = &ipg_clk,
@@ -695,7 +784,7 @@ clk_t *ps_clocks[] = {
  */
 freq_t ps_freq_default[] = {
     [CLK_MASTER]   =  24 * MHZ,
-    [CLK_PLL2  ]   = 528 * MHZ,
+    [CLK_PLL2]     = 528 * MHZ, /* PLL_SYS */
     [CLK_MMDC_CH0] = 528 * MHZ,
     [CLK_AHB]      = 132 * MHZ,
     [CLK_IPG]      =  66 * MHZ,

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -64,11 +64,12 @@
 #define PLL_USB_DIV_MASK        0x3
 #define PLL_USB_GET_DIV(x)      ((x) & PLL_USB_DIV_MASK)
 
-
-#define CLKGATE_OFF    0x0
-#define CLKGATE_ON_RUN 0x2
-#define CLKGATE_ON_ALL 0x3
-#define CLKGATE_MASK   CLKGATE_ON_ALL
+/* clock gating in CCM_CCGRn */
+#define CLKGATE_MODE_OFF        0x0
+#define CLKGATE_MODE_ON_RUN     0x1
+#define CLKGATE_MODE_RESERVED   0x2
+#define CLKGATE_MODE_ON_ALL     0x3
+#define CLKGATE_MODE_MASK       0x3
 
 #define CLKO1_SRC_AHB       (0xBU << 0)
 #define CLKO1_SRC_IPG       (0xCU << 0)
@@ -884,20 +885,49 @@ static clk_t *_clko_init(clk_t *clk)
 static struct clock clko1_clk = { CLK_OPS(CLKO1, clko, NULL) };
 static struct clock clko2_clk = { CLK_OPS(CLKO2, clko, NULL) };
 
-static int imx6_gate_enable(clock_sys_t *clock_sys, enum clock_gate gate, enum clock_gate_mode mode)
+static int imx6_gate_enable(
+    clock_sys_t *clock_sys,
+    enum clock_gate gate,
+    enum clock_gate_mode mode)
 {
     assert(clk_regs.ccm);
-    assert(mode == CLKGATE_ON);
-    (void)assert(gate >= 0);
-    assert(gate < 112);
 
-    uint32_t v;
-    uint32_t reg = gate / 16;
+    if (gate > 112)
+    {
+        LOG_ERROR("invalid gate %d", gate);
+        return -1;
+    }
+
+    uint32_t m;
+    switch (mode)
+    {
+        case CLKGATE_ON:
+            m = CLKGATE_MODE_ON_ALL;
+            break;
+
+        case CLKGATE_IDLE:
+            LOG_ERROR("CLKGATE_IDLE not supported for gate %d", gate);
+            return -1;
+
+        case CLKGATE_SLEEP:
+            m = CLKGATE_MODE_ON_RUN;
+            break;
+
+        case CLKGATE_OFF:
+            m = CLKGATE_MODE_OFF;
+            break;
+
+        default:
+            assert(!"Invalid clock gate mode");
+            return -1;
+    }
+
+    uint32_t volatile *reg = &clk_regs.ccm->ccgr[gate / 16];
     uint32_t shift = (gate & 0xf) * 2;
-    v = clk_regs.ccm->ccgr[reg];
-    v &= ~(CLKGATE_MASK << shift);
-    v |= (CLKGATE_ON_ALL << shift);
-    clk_regs.ccm->ccgr[reg] = v;
+
+    /* clear mask and set net clock gating mode */
+    *reg = (*reg & ~(CLKGATE_MODE_MASK << shift)) | (m << shift);
+
     return 0;
 }
 

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -65,7 +65,7 @@
 #define CLKO2_ENABLE        (1U << 24)
 #define CLKO_SEL            (1U << 8)
 
-struct ccm_regs {
+typedef volatile struct {
     uint32_t ccr;      /* 0x000 */
     uint32_t ccdr;     /* 0x004 */
     uint32_t csr;      /* 0x008 */
@@ -94,16 +94,16 @@ struct ccm_regs {
     uint32_t ccgr[7];  /* 0x068 */
     uint32_t res2[1];
     uint32_t cmeor;    /* 0x088 */
-};
+} ccm_regs_t;
 
-typedef struct {
+typedef volatile struct {
     uint32_t val;                    /* 0x00 */
     uint32_t set;                    /* 0x04 */
     uint32_t clr;                    /* 0x08 */
     uint32_t tog;                    /* 0x0C */
 } alg_sct_t;
 
-struct ccm_alg_usbphy_regs {
+typedef volatile struct {
     alg_sct_t vbus_detect;           /* 0x00 */
     alg_sct_t chrg_detect;           /* 0x10 */
     uint32_t vbus_detect_stat;       /* 0x20 */
@@ -111,10 +111,10 @@ struct ccm_alg_usbphy_regs {
     uint32_t chrg_detect_stat;       /* 0x30 */
     uint32_t res1[3];
     uint32_t res2[4];
-    alg_sct_t misc;                  /* 0x50 */
-};
+    alg_sct_t misc;                  /* +0x50 */
+} ccm_alg_usbphy_regs_t;
 
-struct ccm_alg_regs {
+typedef volatile struct {
     /* PLL_ARM */
     alg_sct_t pll_arm;               /* 0x000 */
     /* PLL_USB * 2 */
@@ -157,15 +157,14 @@ struct ccm_alg_regs {
     /* USB phy control is implemented here for the sake of componentisation
      * since it shares the same register space.
      */
-    struct ccm_alg_usbphy_regs phy1; /* 0x1a0 */
-    struct ccm_alg_usbphy_regs phy2; /* 0x200 */
+    ccm_alg_usbphy_regs_t phy[2];    /* 0x1a0, 0x200 */
     uint32_t digprog;                /* 0x260 */
-};
+} ccm_alg_regs_t;
 
-static volatile struct clock_regs {
-    struct ccm_regs      *ccm;
-    struct ccm_alg_regs *alg;
-} clk_regs = {.ccm = NULL, .alg = NULL};
+static struct {
+    ccm_regs_t     *ccm;
+    ccm_alg_regs_t *alg;
+} clk_regs = { .ccm = NULL, .alg = NULL};
 
 struct pll2_regs {
     uint32_t ctrl;

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -41,9 +41,16 @@
 #define PLL_SYS_SS_EN           BIT(15)
 #define PLL_SYS_SS_STEP(x)      ((x) & 0x7fff)
 
-/* ENET PLL */
-#define PLL_ENET_DIV_MASK 0x3
-#define PLL_ENET_ENABLE   BIT(13)
+/* PLL_ENET (PLL6), disabled on reset, runs at a fixed multiplier 20+(5/6)
+ * which based on the 24 MHz oscillator as reference clock gives a 500 MHz clock
+ * (24 MHz * (20+(5/6)) = 500 MHz). This use used to generate the frequencies
+ * 125 MHz (for PCIe and gigabit ethernet), 100 MHz (for SATA) and 50 or 25 MHz
+ * for the external ethernet interface.
+ */
+#define PLL_ENET_ENABLE_100M    BIT(20)
+#define PLL_ENET_ENABLE_125M    BIT(19)
+#define PLL_ENET_DIV_MASK       0x3
+#define PLL_ENET_GET_DIV(x)     ((x) & PLL_ENET_DIV_MASK)
 
 /* PLL_USB. There is PLL3 (USB1_PLL or 480 PLL) that runs at a fixed multiplier
  * 20 and based on the 24 MHz oscillator creates a 480 MHz reference clock
@@ -325,57 +332,100 @@ static struct clock arm_clk = { CLK_OPS(ARM, arm, NULL) };
 
 static freq_t _enet_get_freq(clk_t *clk)
 {
-    uint32_t div;
-    uint32_t fin;
-
-    fin = clk_get_freq(clk->parent);
-    div = clk_regs.alg->pll_enet.val;
-    div &= PLL_ENET_DIV_MASK;
-    switch (div) {
-    case 3:
-        return 5 * fin;
-    case 2:
-        return 4 * fin;
-    case 1:
-        return 2 * fin;
-    case 0:
-        return 1 * fin;
-    default:
-        return 0 * fin;
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
+        return 0;
     }
+
+    uint32_t v = clk_regs.alg->pll_enet.val;
+
+    /* clock output enabled? */
+    if (!(v & PLL_ENABLE))
+    {
+        return 0;
+    }
+
+    if (v & PLL_BYPASS)
+    {
+        /* bypass on
+         * 0x0 source is 24MHz oscillator
+         * 0x1 source is CLK1_N/CLK1_P
+         * 0x2 source is CLK2_N/CLK2_P
+         * 0x3 source is CLK1_N/CLK1_P XOR CLK2_N/CLK2_P
+         */
+        unsigned int src = PLL_GET_BYPASS_SRC(v);
+        switch (src) {
+            case 0: return 24 * MHZ;
+            default: break;
+        }
+        LOG_ERROR("can determine frequency for bypass sources %u", src);
+        return 0;
+    }
+
+    /* PLL enabled, but powered down? */
+    if (v & PLL_PWR_DOWN)
+    {
+        return 0;
+    }
+
+    unsigned int div = v & PLL_ENET_DIV_MASK;
+    switch (div) {
+        case 0: return  25 * MHZ;
+        case 1: return  50 * MHZ;
+        case 2: return 100 * MHZ;
+        case 3: return 125 * MHZ;
+        default: break;
+    }
+    LOG_ERROR("unsupported ENET PLL divider %u", v);
+    return 0;
 }
 
 static freq_t _enet_set_freq(clk_t *clk, freq_t hz)
 {
-    uint32_t div, fin;
-    uint32_t v;
-    if (clk_regs.alg == NULL) {
-        return clk_get_freq(clk);
+    if (!clk_regs.alg) {
+        LOG_ERROR("clk_regs.alg is NULL, clocks not initialised properly");
+        return 0;
     }
-    fin = clk_get_freq(clk->parent);
-    if (hz >= 5 * fin) {
-        div = 3;
-    } else if (hz >= 4 * fin) {
-        div = 2;
-    } else if (hz >= 2 * fin) {
-        div = 1;
-    } else if (hz >= 1 * fin) {
-        div = 0;
-    } else {
-        div = 0;
+
+    alg_sct_t* pll = &clk_regs.alg->pll_enet;
+
+    uint32_t div;
+    switch (hz) {
+        case 125 * MHZ: div = 3; break;
+        case 100 * MHZ: div = 2; break;
+        case  50 * MHZ: div = 1; break;
+        case  25 * MHZ: div = 0; break;
+        default:
+            LOG_ERROR("unsupported ENET clock frequency %d", hz);
+            return 0;
     }
-    /* bypass on */
-    clk_regs.alg->pll_enet.set = PLL_BYPASS;
-    v = PLL_ENET_ENABLE | PLL_BYPASS;
-    clk_regs.alg->pll_enet.val = v;
-    /* Change the frequency */
-    v = clk_regs.alg->pll_enet.val & ~(PLL_ENET_DIV_MASK);
-    v |= div;
-    clk_regs.alg->pll_enet.val = v;
-    while (!(clk_regs.alg->pll_enet.val & PLL_LOCK));
-    /* bypass off */
-    clk_regs.alg->pll_enet.clr = PLL_BYPASS;
-    printf("Set ENET frequency to %ld Mhz... ", (long int)clk_get_freq(clk) / MHZ);
+
+    // ENET requires ahb_clk_root to be at least 125 MHz. In the clock tree
+    // PLL_SYS feeds CLK_MMDC_CH0 which feeds CLK_AHB. For CLK_AHB the default
+    // divider is 4, set via CBCDR.AHB_PODF, so setting PLL_SYS to the standard
+    // 528 MHz will result in an AHB clock of 132 MHz.
+    freq_t f = clk_get_freq( clk_get_clock(clk->clk_sys, CLK_AHB) );
+    if (f < (125 * MHZ))
+    {
+        LOG_INFO("setting system PLL from %llu to 528 MHz", f);
+        clk_set_freq(clk_get_clock(clk->clk_sys, CLK_PLL2), 528 * MHZ);
+        f = clk_get_freq( clk_get_clock(clk->clk_sys, CLK_AHB) );
+        if (f < (125 * MHZ))
+        {
+            LOG_ERROR("clock tree setup broken, AHB clock is %llu", f);
+            return 0;
+        }
+    }
+
+    int ret = change_pll(pll, PLL_ENET_DIV_MASK, div);
+    if (0 != ret)
+    {
+        LOG_ERROR("waiting for PLL_ENET lock aborted, code %d", ret);
+        return 0;
+    }
+
+    clk_gate_enable(clk_get_clock_sys(clk), enet_clock, CLKGATE_ON);
+
     return clk_get_freq(clk);
 }
 
@@ -532,7 +582,11 @@ static freq_t _mmdc_ch0_get_freq(clk_t *clk)
 
 static freq_t _mmdc_ch0_set_freq(clk_t *clk, freq_t hz)
 {
-    /* TODO there is a mux here */
+    /* TODO: there are the two MUXers here:
+     *         - CCM Bus Clock Multiplexer CBCMR.PRE_PERIPH_CLK_SEL
+     *         - CCM Bus Clock Divider CBCDR.PERIPH_CLK_SEL
+     *       by default they route the clock PLL_SYS (PLL2)
+     */
     assert(hz == 528 * MHZ);
     return clk_set_freq(clk->parent, hz);
 }
@@ -563,11 +617,16 @@ static struct clock mmdc_ch0_clk = { CLK_OPS(MMDC_CH0, mmdc_ch0, NULL) };
 
 static freq_t _ahb_get_freq(clk_t *clk)
 {
+    /* ToDo: read divider from CBCDR.AHB_PODF */
     return clk_get_freq(clk->parent) / 4;
 }
 
 static freq_t _ahb_set_freq(clk_t *clk, freq_t hz)
 {
+    /* ToDo: we assume the default value CBCDR.AHB_PODF = b011 has not been
+     * changed and thus the divider is 4 (132 MHZ * 4 = 528 MHz).
+     */
+    assert(hz == 132 * MHZ);
     return clk_set_freq(clk->parent, hz * 4);
 }
 

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -18,9 +18,12 @@
 #define CCM_ANALOG_PADDR 0x020C8000
 #define CCM_ANALOG_SIZE      0x1000
 
-/* Generic PLL */
-#define PLL_LOCK          BIT(31)
-#define PLL_BYPASS        BIT(16)
+/* common flags for all PLLs */
+#define PLL_LOCK                BIT(31)
+#define PLL_BYPASS              BIT(16)
+#define PLL_GET_BYPASS_SRC(x)   (((x) >> 14) & 0x3)
+#define PLL_ENABLE              BIT(13)
+#define PLL_PWR_DOWN            BIT(12)
 
 /* SYS PLL */
 #define PLL_ARM_DIV_MASK  0x7F

--- a/libutils/include/utils/util.h
+++ b/libutils/include/utils/util.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2020, HENSOLDT Cyber GmbH
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -59,5 +60,6 @@
  * all ZF_LOG output, settings it to ZF_LOG_FATAL will
  * only display fatal outputs.
  */
-#define LOG_ERROR(...) ZF_LOGE(__VA_ARGS__)
-#define LOG_INFO(...) ZF_LOGI(__VA_ARGS__)
+#define LOG_ERROR(...)  ZF_LOGE(__VA_ARGS__)
+#define LOG_WARN(...)   ZF_LOGW(__VA_ARGS__)
+#define LOG_INFO(...)   ZF_LOGI(__VA_ARGS__)


### PR DESCRIPTION
There is a RPi4 support PR #60](https://github.com/seL4/util_libs/pull/60) by [Lukas Graber](https://github.com/lulu98) to [mainline util_libs repo](https://github.com/seL4/util_libs). PR has been accepted and closed, but it isn't yet merged into master. Also, the [source branch](https://github.com/Hensoldt-Cyber/util_libs/tree/rpi4_porting) from Hensoldt-Cyber repo does not exist anymore, and [Axel's](https://github.com/axel-h) [patch branch](https://github.com/Hensoldt-Cyber/util_libs/tree/axel-patch-7) is the only one still containing [the needed patches](https://github.com/Hensoldt-Cyber/util_libs/commit/b6f99879e59950f39ee35472ab15eac1efb0f139), besides hacking the support together by hand.

So, we are going to use this then.