### PR TITLE
util-libs: BCM2711 GPIO and serial fixes

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -34,9 +34,11 @@ config_choice(
     "ega;LibPlatSupportX86ConsoleDeviceEGA;LIB_PLAT_SUPPORT_SERIAL_TEXT_EGA;KernelPlatPC99"
 )
 
+set(_link_arm_vm_Config_lib "")
 set(LibPlatSupportMach "")
 if(KernelPlatformRpi3 OR KernelPlatformRpi4)
     set(LibPlatSupportMach "bcm283x")
+    set(_link_arm_vm_Config_lib "arm_vm_Config")
 elseif(NOT ${KernelArmMach} STREQUAL "")
     # falling back to kernel settings is done to keep legacy compatibility
     set(LibPlatSupportMach "${KernelArmMach}")
@@ -164,6 +166,7 @@ target_link_libraries(
     utils
     fdt
     sel4_autoconf
+    ${_link_arm_vm_Config_lib}
     platsupport_Config
     ${irqchip_modules}
 )

--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
@@ -53,6 +53,14 @@ struct aux_sys {
     int (*get_irq_stat)(aux_sys_t *aux_sys, aux_dev_id_t id);
 
     /**
+     * Query AUX device status.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 1 if device is enabled, 0 if not. <0 on error.
+     */
+    int (*status)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+    /**
      * Enable AUX device.
      * @param[in]   aux_sys    Initialized AUX driver instance.
      * @param[in]   id         ID of the AUX device.

--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+#include <utils/util.h>
+#include <platsupport/io.h>
+
+#define BUS_ADDR_OFFSET     0x7E000000
+#define PADDR_OFFSET        0xFE000000
+
+/*
+ * The AUX block contains 3 auxiliary
+ * peripherals on the bcm2711 (section 2.1.)
+ *      find in seL4/tools/dts/rpi4.dts under
+ *          /soc/aux@7e215000
+ *          ->  /soc/serial@7e215040
+ *          ->  /soc/spi@7e215080
+ *          ->  /soc/spi@7e2150c0
+ */
+#define AUX_BUSADDR      0x7E215000
+
+#define AUX_PADDR        (AUX_BUSADDR - BUS_ADDR_OFFSET + PADDR_OFFSET)
+#define AUX_SIZE         0x1000
+
+/*
+ * BCM2711 TRM
+ * All AUX device interrupts are on the same interrupt #
+ * section 6.2.4. VideoCore interrupts:             29
+ * section 6.3.   GIC-400 - VC peripheral IRQs:     96
+ * => mini UART IRQ: 96 + 29 = 125
+ */
+#define AUX_IRQ          (125)
+
+typedef enum aux_dev_id {
+    BCM2711_AUX_UART,
+    BCM2711_AUX_SPI1,
+    BCM2711_AUX_SPI2,
+
+    NUM_AUX_DEV
+} aux_dev_id_t;
+
+typedef struct aux_sys aux_sys_t;
+
+struct aux_sys {
+    /** Get AUX device IRQ pending status.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 0/1 on success. Non-zero on error.
+     */
+    int (*get_irq_stat)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+    /**
+     * Enable AUX device.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 0 on success. Non-zero on error.
+     */
+    int (*enable)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+    /**
+     * Disable AUX device. Disabling an AUX device also
+     * disables access to the respective devices' registers.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 0 on success. Non-zero on error.
+     */
+    int (*disable)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+/// platform specific private data
+    void *priv;
+};
+
+/**
+ * Initialise the BCM2711 AUX system handler instance.
+ * @param[in]  io_ops    IO operations for device initialisation.
+ * @param[out] aux_sys   A handle to a AUX subsystem to populate.
+ * @return               0 on success. Non-zero on error.
+ */
+int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys);
+
+/**
+ * De-initialise the BCM2711 AUX system handler instance.
+ * @param[in]  io_ops    IO operations for device initialisation.
+ * @param[out] aux_sys   A handle to a AUX subsystem to populate.
+ * @return               0 on success. Non-zero on error.
+ */
+int bcm2711_aux_sys_destroy(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys);

--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
@@ -74,17 +74,25 @@ struct aux_sys {
 };
 
 /**
+ * Initialise the BCM2711 AUX system handler instance with externally mapped MMIO page.
+ * @param[in]  page      Mapping for AUX registers page.
+ * @param[out] aux_sys   Handle to AUX system instance to populate.
+ * @return               0 on success. Non-zero on error.
+ */
+int bcm2711_aux_sys_init_ext(void *page, aux_sys_t *aux_sys);
+
+/**
  * Initialise the BCM2711 AUX system handler instance.
- * @param[in]  io_ops    IO operations for device initialisation.
- * @param[out] aux_sys   A handle to a AUX subsystem to populate.
+ * @param[in]  io_ops    I/O operations for device initialisation.
+ * @param[out] aux_sys   Handle to AUX system instance to populate.
  * @return               0 on success. Non-zero on error.
  */
 int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys);
 
 /**
  * De-initialise the BCM2711 AUX system handler instance.
- * @param[in]  io_ops    IO operations for device initialisation.
- * @param[out] aux_sys   A handle to a AUX subsystem to populate.
+ * @param[in]  io_ops    I/O operations for device initialisation.
+ * @param[out] aux_sys   Handle to AUX system instance to populate.
  * @return               0 on success. Non-zero on error.
  */
 int bcm2711_aux_sys_destroy(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys);

--- a/libplatsupport/src/plat/bcm2711/aux.c
+++ b/libplatsupport/src/plat/bcm2711/aux.c
@@ -127,15 +127,29 @@ int bcm2711_aux_init_common(aux_sys_t *aux_sys)
     return 0;
 }
 
+int bcm2711_aux_sys_init_ext(void *page, aux_sys_t *aux_sys)
+{
+    if (page != NULL) {
+        aux_ctx.regs = page;
+
+        ZF_LOGD("Using externally mapped AUX registers frame: "
+                "vaddr -> 0x%" PRIxPTR, (uintptr_t)(aux_ctx.regs));
+
+        return bcm2711_aux_init_common(aux_sys);
+    }
+
+    return -EINVAL;
+}
+
 int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
 {
-    if ((NULL == io_ops)
-        || (NULL == aux_sys)) {
+    if ((io_ops == NULL)
+        || (aux_sys == NULL)) {
         return -EINVAL;
     }
 
     MAP_IF_NULL(io_ops, AUX, aux_ctx.regs);
-    if (NULL == aux_ctx.regs) {
+    if (aux_ctx.regs == NULL) {
         ZF_LOGF("Failed to map BCM2711 AUX registers frame.");
         return -ENOMEM;
     }
@@ -149,12 +163,12 @@ int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
 
 int bcm2711_aux_sys_destroy(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
 {
-    if ((NULL == io_ops)
-        || (NULL == aux_sys)) {
+    if ((io_ops == NULL)
+        || (aux_sys == NULL)) {
         return -EINVAL;
     }
 
-    if (NULL != aux_sys->priv) {
+    if (aux_sys->priv != NULL) {
         ZF_LOGD("Unmapping AUX registers frame: vaddr -> 0x%" PRIxPTR, (uintptr_t)(aux_sys->priv));
         ps_io_unmap(&(io_ops->io_mapper), aux_sys->priv, AUX_SIZE);
     }

--- a/libplatsupport/src/plat/bcm2711/aux.c
+++ b/libplatsupport/src/plat/bcm2711/aux.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <platsupport/plat/aux.h>
+#include "../../services.h"
+
+#define AUX_IRQ_MINIUART_IRQ  BIT(0) /* Mini-UART IRQ pending status bit. */
+#define AUX_IRQ_SPI1_IRQ      BIT(1) /* AUX SPI1 IRQ pending status bit. */
+#define AUX_IRQ_SPI2_IRQ      BIT(2) /* AUX SPI2 IRQ pending status bit. */
+
+#define AUX_ENA_MINIUART_ENA  BIT(0) /* Mini-UART enable/disable bit. */
+#define AUX_ENA_SPI1_ENA      BIT(1) /* AUX SPI1 enable/disable bit. */
+#define AUX_ENA_SPI2_ENA      BIT(2) /* AUX SPI2 enable/disable bit. */
+
+/* AUX registers definition. */
+typedef volatile struct {
+    uint32_t    aux_irq;  // 0x00: AUX IRQ pending status
+    uint32_t    aux_ena;  // 0x04: AUX device enable/disable
+} bcm2711_aux_regs_t;
+
+
+static struct bcm2711_aux {
+    bcm2711_aux_regs_t *regs;
+} aux_ctx;
+
+static inline bcm2711_aux_regs_t *aux_get_regs(aux_sys_t *aux_sys)
+{
+    return (((struct bcm2711_aux *)aux_sys->priv)->regs);
+};
+
+
+static int bcm2711_aux_get_irq_stat(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        ret = (int)(regs->aux_irq & AUX_IRQ_MINIUART_IRQ);
+        break;
+    case BCM2711_AUX_SPI1:
+        ret = (int)(regs->aux_irq & AUX_IRQ_SPI1_IRQ);
+        break;
+    case BCM2711_AUX_SPI2:
+        ret = (int)(regs->aux_irq & AUX_IRQ_SPI2_IRQ);
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+static int bcm2711_aux_enable(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        regs->aux_ena |= AUX_ENA_MINIUART_ENA;
+        break;
+    case BCM2711_AUX_SPI1:
+        regs->aux_ena |= AUX_ENA_SPI1_ENA;
+        break;
+    case BCM2711_AUX_SPI2:
+        regs->aux_ena |= AUX_ENA_SPI2_ENA;
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+static int bcm2711_aux_disable(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        regs->aux_ena &= ~AUX_ENA_MINIUART_ENA;
+        break;
+    case BCM2711_AUX_SPI1:
+        regs->aux_ena &= ~AUX_ENA_SPI1_ENA;
+        break;
+    case BCM2711_AUX_SPI2:
+        regs->aux_ena &= ~AUX_ENA_SPI2_ENA;
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+int bcm2711_aux_init_common(aux_sys_t *aux_sys)
+{
+    assert(aux_sys);
+
+    aux_sys->priv = (void *) &aux_ctx;
+    aux_sys->get_irq_stat = &bcm2711_aux_get_irq_stat;
+    aux_sys->enable = &bcm2711_aux_enable;
+    aux_sys->disable = &bcm2711_aux_disable;
+
+    return 0;
+}
+
+int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
+{
+    if ((NULL == io_ops)
+        || (NULL == aux_sys)) {
+        return -EINVAL;
+    }
+
+    MAP_IF_NULL(io_ops, AUX, aux_ctx.regs);
+    if (NULL == aux_ctx.regs) {
+        ZF_LOGF("Failed to map BCM2711 AUX registers frame.");
+        return -ENOMEM;
+    }
+
+    ZF_LOGD("Mapped AUX registers frame: "
+            "paddr / vaddr -> 0x% " PRIxPTR " / 0x% " PRIxPTR,
+            (uintptr_t) AUX_PADDR, (uintptr_t)(aux_ctx.regs));
+
+    return bcm2711_aux_init_common(aux_sys);
+}
+
+int bcm2711_aux_sys_destroy(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
+{
+    if ((NULL == io_ops)
+        || (NULL == aux_sys)) {
+        return -EINVAL;
+    }
+
+    if (NULL != aux_sys->priv) {
+        ZF_LOGD("Unmapping AUX registers frame: vaddr -> 0x%" PRIxPTR, (uintptr_t)(aux_sys->priv));
+        ps_io_unmap(&(io_ops->io_mapper), aux_sys->priv, AUX_SIZE);
+    }
+
+    return 0;
+}

--- a/libplatsupport/src/plat/bcm2711/aux.c
+++ b/libplatsupport/src/plat/bcm2711/aux.c
@@ -61,6 +61,33 @@ static int bcm2711_aux_get_irq_stat(aux_sys_t *aux_sys, aux_dev_id_t id)
     return ret;
 }
 
+static int bcm2711_aux_status(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        ret = regs->aux_ena | AUX_ENA_MINIUART_ENA;
+        break;
+    case BCM2711_AUX_SPI1:
+        ret = regs->aux_ena | AUX_ENA_SPI1_ENA;
+        break;
+    case BCM2711_AUX_SPI2:
+        ret = regs->aux_ena | AUX_ENA_SPI2_ENA;
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
 static int bcm2711_aux_enable(aux_sys_t *aux_sys, aux_dev_id_t id)
 {
     assert(aux_sys);
@@ -121,6 +148,7 @@ int bcm2711_aux_init_common(aux_sys_t *aux_sys)
 
     aux_sys->priv = (void *) &aux_ctx;
     aux_sys->get_irq_stat = &bcm2711_aux_get_irq_stat;
+    aux_sys->status = &bcm2711_aux_status;
     aux_sys->enable = &bcm2711_aux_enable;
     aux_sys->disable = &bcm2711_aux_disable;
 

--- a/libplatsupport/src/plat/bcm2711/mini_serial.c
+++ b/libplatsupport/src/plat/bcm2711/mini_serial.c
@@ -415,8 +415,17 @@ int mini_uart_init(const struct dev_defn *defn,
 
     int ret = 0;
 
-    /* Initialize AUX subsystem handle */
-    ret = bcm2711_aux_sys_init(ops, &aux);
+    /* Initialize AUX subsystem handle
+     *
+     * NOTE: current system limits the smallest shareable
+     * (untyped) MMIO region to 4K page, which is too large
+     * to separate between the AUX MMIO range and mini-UART
+     * range (0x40 bytes between the registers).
+     *
+     * Therefore we must share our MMIO mapping with the AUX
+     * subsystem.
+     */
+    ret = bcm2711_aux_sys_init_ext(vaddr, &aux);
     if (ret != 0) {
         ZF_LOGE("Failed to initialize AUX subsystem! %i", ret);
         return ret;

--- a/libplatsupport/src/plat/bcm2711/mini_serial.c
+++ b/libplatsupport/src/plat/bcm2711/mini_serial.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021, Hensoldt Cyber GmbH
+ * Copyright 2022, Technology Innovation Institute
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,10 +9,94 @@
 #include <stdint.h>
 #include <string.h>
 #include <platsupport/serial.h>
+#include <platsupport/plat/aux.h>
 #include <platsupport/plat/serial.h>
 #include "serial.h"
 #include "mini_serial.h"
 
+/*
+ * The Raspberry Pi's mini-UART/AUX UART has some shenanigans
+ * going on as the TRM is not correct on many parts. The UART
+ * device works essentially the same as on BCM2837/BCM2835, so
+ * the same erratas apply here.
+ *
+ * See following resources for details:
+ *     BCM2711 TRM, Section 2.2. Mini UART.
+ *     https://elinux.org/BCM2835_datasheet_errata
+ *     https://elinux.org/RPi_Hardware
+ */
+
+/* BCM2711 TRM page 17. Interrupt ID definitions. */
+enum mu_iir_source {
+    MU_NO_INTERRUPTS = 0, /* No interrupts pending. */
+    MU_TXE_INTERRUPT = 1, /* TX FIFO empty causing interrupt. */
+    MU_RXD_INTERRUPT = 2  /* RX FIFO data received causing interrupt. */
+};
+
+/* BCM2711 TRM pages 20-21. Auto-flow-control RTS threshold definitions. */
+enum mu_cntl_flow_level {
+    FIFO_3B_LEFT = 0,  /* RTS de-asserted when RX FIFO has 3 bytes left. */
+    FIFO_2B_LEFT = 1,  /* RTS de-asserted when RX FIFO has 2 bytes left. */
+    FIFO_1B_LEFT = 2,  /* RTS de-asserted when RX FIFO has 1 bytes left. */
+    FIFO_4B_LEFT = 3   /* RTS de-asserted when RX FIFO has 4 bytes left. */
+};
+
+#define MU_FIFO_SIZE          (8) /* 8-byte FIFOs for RX & TX. */
+
+#define MU_IO_DATA_MASK       MASK(8) /* IO register data bits mask. (Bits 7:0). */
+
+/* TRM has errors regarding IER register, see errata comment above */
+#define MU_IER_RXD_IRQ        BIT(0) /* Interrupt if RX FIFO holds at least 1 byte. */
+#define MU_IER_TXE_IRQ        BIT(1) /* Interrupt if TX FIFO is empty. */
+#define MU_IER_LSI_IRQ        BIT(2) /* RX Line Status Interrupt on overrun/parity/framing errors etc. */
+#define MU_IER_MSI_IRQ        BIT(3) /* Modem Status Interrupt on changing states to either: To Send(CTS), Data Set Ready(DSR). */
+
+#define MU_IIR_PENDING        BIT(0) /* This bit is clear if there is an interrupt pending. */
+#define MU_IIR_SOURCE_MASK    (MASK(3) & ~BIT(0)) /* Interrupt source bits mask. (Bits 2:1). */
+#define MU_IIR_SOURCE_SHIFT   (1)
+#define MU_IIR_RXF_CLEAR      BIT(1) /* RX FIFO clear. */
+#define MU_IIR_TXF_CLEAR      BIT(2) /* TX FIFO clear. */
+
+#define MU_LCR_DATASIZE       BIT(0) /* 0 -> 7-bit mode, 1 -> 8-bit mode. */
+#define MU_LCR_BREAK          BIT(6) /* This bit is set if TX line is pulled low for at least 12 bit times. (Break condition).*/
+#define MU_LCR_DLAB           BIT(7) /* DLAB access bit. */
+
+#define MU_MCR_RTS            BIT(1) /* 0 -> RTS is high, 1 -> RTS is low. */
+
+#define MU_LSR_RXF_DATAREADY  BIT(0) /* This bit is set when RX FIFO holds at least one byte. */
+#define MU_LSR_RX_OVERRUN     BIT(1) /* This bit is set when RX FIFO was overrun. */
+#define MU_LSR_TXF_HASSPACE   BIT(5) /* This bit is set if the TX FIFO can accept at least one byte.*/
+#define MU_LSR_TXIDLE         BIT(6) /* This bit is set if the TX FIFO is empty and the TX is idle. (Finished shifting out the last bit). */
+
+#define MU_MSR_CTS            BIT(5) /* 0 -> CTS is high, 1 -> CTS is low. */
+
+#define MU_CNTL_RXE           BIT(0) /* Receiver (RX) enable. */
+#define MU_CNTL_TXE           BIT(1) /* Transmitter (TX) enable. */
+#define MU_CNTL_RTSEN         BIT(2) /* 1 -> RTS line will de-assert if RX FIFO reaches auto-flow level, 0 -> RTS is controlled by the AUX_MU_MCR_REG register bit 1. */
+#define MU_CNTL_CTSEN         BIT(3) /* 1 -> TX will stop when CTS line is de-asserted, 0 -> CTS line is ignored. */
+#define MU_CNTL_RTS_LVL_MASK  (MASK(5) & ~MASK(3)) /* RTS auto-flow-control bits, specifies the # of bytes left in RX FIFO until RTS is de-asserted. */
+#define MU_CNTL_RTS_LVL_SHIFT (3)
+#define MU_CNTL_RTS_INV       BIT(6) /* 1 -> RTS auto flow assert level is low, 0 -> RTS auto flow assert level is high. */
+#define MU_CNTL_CTS_INV       BIT(7) /* 1 -> CTS auto flow assert level is low, 0 -> CTS auto flow assert level is high. */
+
+#define MU_STAT_RXF_DATAREADY BIT(0) /* This bit is set when RX FIFO holds at least one byte. */
+#define MU_STAT_TXF_HASSPACE  BIT(1) /* This bit is set if the TX FIFO can accept at least one byte.*/
+#define MU_STAT_RXIDLE        BIT(2) /* This bit is set if the receiver is at idle. */
+#define MU_STAT_TXIDLE        BIT(3) /* This bit is set if the transmitter is at idle. */
+#define MU_STAT_RX_OVERRUN    BIT(4) /* This bit is set when RX FIFO was overrun. */
+#define MU_STAT_TXF_FULL      BIT(5) /* Inverse of bit 1. This bit is set if TX FIFO is completely full. */
+#define MU_STAT_RTS           BIT(6) /* RTS line status. */
+#define MU_STAT_CTS           BIT(7) /* CTS line status. */
+#define MU_STAT_TXF_EMPTY     BIT(8) /* This bit is set if TX FIFO is completely empty (can accept 8 bytes). */
+#define MU_STAT_TXDONE        BIT(9) /* This bit is set if TX FIFO is completely empty and the transmitter is at idle. (AND of bits 3 & 8). */
+#define MU_STAT_RXF_LVL_MASK  ((MASK(20) & ~MASK(16))) /* # of bytes in RX FIFO. (0..8). */
+#define MU_STAT_RXF_LVL_SHIFT (16)
+#define MU_STAT_TXF_LVL_MASK  ((MASK(28) & ~MASK(24))) /* # of bytes in TX FIFO. (0..8). */
+#define MU_STAT_TXF_LVL_SHIFT (24)
+
+#define MU_BAUD_BAUD_MASK     MASK(16) /* 16-bits baudrate value. */
+
+/* Mini-UART registers definition. */
 typedef volatile struct mini_uart_regs_s {
     uint32_t mu_io;         // 0x40: mini UART I/O Data
     uint32_t mu_ier;        // 0x44: mini UART interrupt enable
@@ -27,20 +112,270 @@ typedef volatile struct mini_uart_regs_s {
 }
 mini_uart_regs_t;
 
-/* This bit is set if the transmit FIFO can accept at least one byte.*/
-#define MU_LSR_TXEMPTY   BIT(5)
-/* This bit is set if the transmit FIFO is empty and the
- * transmitter is idle. (Finished shifting out the last bit). */
-#define MU_LSR_TXIDLE    BIT(6)
-#define MU_LSR_RXOVERRUN BIT(1)
-#define MU_LSR_DATAREADY BIT(0)
+static aux_sys_t aux;
 
-#define MU_LCR_DLAB      BIT(7)
-#define MU_LCR_BREAK     BIT(6)
-#define MU_LCR_DATASIZE  BIT(0)
+static inline mini_uart_regs_t *mini_uart_get_priv(ps_chardevice_t *dev)
+{
+    return ((mini_uart_regs_t *)dev->vaddr);
+}
+
+static inline int mini_uart_flush_fifos(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+
+    regs->mu_iir |= (MU_IIR_RXF_CLEAR | MU_IIR_TXF_CLEAR);
+
+    return 0;
+}
+
+static inline int mini_uart_enable(ps_chardevice_t *dev, aux_sys_t *aux)
+{
+    if (dev == NULL ||
+        aux == NULL) {
+        return -EINVAL;
+    }
+
+    int ret = 0;
+
+    ret = aux->enable(aux, BCM2711_AUX_UART);
+
+    if (ret != 0) {
+        ZF_LOGE("Failed to enable mini-UART in AUX subsystem! %i", ret);
+        return ret;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    regs->mu_cntl |= (MU_CNTL_RXE | MU_CNTL_TXE);
+
+    return 0;
+}
+
+static inline int mini_uart_disable(ps_chardevice_t *dev, aux_sys_t *aux, bool disable_aux)
+{
+    if (dev == NULL ||
+        aux == NULL) {
+        return -EINVAL;
+    }
+
+    int ret = 0;
+
+    if (disable_aux) {
+
+        ret = aux->disable(aux, BCM2711_AUX_UART);
+
+        if (ret != 0) {
+            ZF_LOGE("Failed to disable mini-UART in AUX subsystem! %i", ret);
+            return ret;
+        }
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    regs->mu_cntl &= ~(MU_CNTL_RXE | MU_CNTL_TXE);
+
+    return 0;
+}
+
+static inline int mini_uart_enable_rx_irq(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    regs->mu_ier |= (MU_IER_RXD_IRQ | MU_IER_LSI_IRQ);
+
+    return 0;
+}
+
+static inline int mini_uart_disable_rx_irq(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    regs->mu_ier &= ~(MU_IER_RXD_IRQ | MU_IER_LSI_IRQ);
+
+    return 0;
+}
+
+static inline int mini_uart_enable_tx_irq(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    regs->mu_ier |= (MU_IER_TXE_IRQ | MU_IER_LSI_IRQ);
+
+    return 0;
+}
+
+static inline int mini_uart_disable_tx_irq(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    regs->mu_ier &= ~(MU_IER_TXE_IRQ | MU_IER_LSI_IRQ);
+
+    return 0;
+}
+
+static inline int mini_uart_disable_interrupts(ps_chardevice_t *dev)
+{
+    return (mini_uart_disable_rx_irq(dev) | mini_uart_disable_tx_irq(dev));
+}
+
+static inline int mini_uart_get_irq_source(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    return (int)((regs->mu_iir & MU_IIR_SOURCE_MASK) >> MU_IIR_SOURCE_SHIFT);
+}
+
+static inline int mini_uart_rxfifo_level(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    return (int)((regs->mu_stat & MU_STAT_RXF_LVL_MASK) >> MU_STAT_RXF_LVL_SHIFT);
+}
+
+static inline int mini_uart_txfifo_level(ps_chardevice_t *dev)
+{
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+    return (int)((regs->mu_stat & MU_STAT_TXF_LVL_MASK) >> MU_STAT_TXF_LVL_SHIFT);
+}
+
+
+static int mini_uart_putchar_blocking(ps_chardevice_t *d, int c)
+{
+    if (d == NULL) {
+        return -EINVAL;
+    }
+
+    const char ch = (const char)c;
+    mini_uart_regs_t *regs = mini_uart_get_priv(d);
+
+    int slots_required = 1;
+    bool print_cr = false;
+    bool complete = false;
+
+    if ((d->flags & SERIAL_AUTO_CR) && (ch == '\n')) {
+        slots_required = 2;
+        print_cr = true;
+    }
+
+    do {
+        int slots_avail = (MU_FIFO_SIZE - mini_uart_txfifo_level(d));
+
+        if (slots_avail >= slots_required) {
+
+            regs->mu_io = ch;
+            if (print_cr) {
+                regs->mu_io = '\r';
+            }
+
+            complete = true;
+        }
+    } while (!complete);
+
+    return 0;
+}
+
+static int mini_uart_putchar_nonblocking(ps_chardevice_t *d, int c)
+{
+    if (d == NULL) {
+        return -EINVAL;
+    }
+
+    const char ch = (const char)c;
+    mini_uart_regs_t *regs = mini_uart_get_priv(d);
+
+    int slots_required = 1;
+    bool print_cr = false;
+    bool complete = false;
+
+    if ((d->flags & SERIAL_AUTO_CR) && (ch == '\n')) {
+        slots_required = 2;
+        print_cr = true;
+    }
+
+    int slots_avail = (MU_FIFO_SIZE - mini_uart_txfifo_level(d));
+
+    if (slots_avail < slots_required) {
+        return EOF;
+    } else {
+        regs->mu_io = ch;
+        if (print_cr) {
+            regs->mu_io = '\r';
+        }
+    }
+
+    return 0;
+}
+
+static int mini_uart_getchar_blocking(ps_chardevice_t *d)
+{
+    if (d == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(d);
+
+    while (!(regs->mu_stat & MU_STAT_RXF_DATAREADY)) {
+        return (int)(regs->mu_io & MU_IO_DATA_MASK);
+    }
+}
+
+static int mini_uart_getchar_nonblocking(ps_chardevice_t *d)
+{
+    if (d == NULL) {
+        return -EINVAL;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(d);
+
+    if (regs->mu_stat & MU_STAT_RXF_DATAREADY) {
+        return (int)(regs->mu_io & MU_IO_DATA_MASK);
+    }
+
+    return EOF;
+}
 
 static void mini_uart_handle_irq(ps_chardevice_t *dev)
 {
+    if (dev == NULL) {
+        return;
+    }
+
+    /*
+     * TODO: how to handle TX interrupts?
+     */
+
+    const int source = mini_uart_get_irq_source(dev);
+    ZF_LOGD("mini-UART interrupt source: %i", source);
+
+    if (MU_RXD_INTERRUPT == source) {
+        mini_uart_enable_rx_irq(dev);
+    } else if (MU_TXE_INTERRUPT == source) {
+        ZF_LOGD("Unhandled TXE interrupt");
+    }
 }
 
 int mini_uart_init(const struct dev_defn *defn,
@@ -51,7 +386,7 @@ int mini_uart_init(const struct dev_defn *defn,
     void *vaddr = chardev_map(defn, ops);
     memset(dev, 0, sizeof(*dev));
     if (vaddr == NULL) {
-        return -1;
+        return -ENOMEM;
     }
 
     // When mapping the virtual address space, the base addresses need to be
@@ -64,7 +399,7 @@ int mini_uart_init(const struct dev_defn *defn,
         break;
     default:
         ZF_LOGE("Mini UART with ID %d does not exist!", defn->id);
-        return -1;
+        return -EINVAL;
         break;
     }
 
@@ -78,19 +413,74 @@ int mini_uart_init(const struct dev_defn *defn,
     dev->ioops      = *ops;
     dev->flags      = SERIAL_AUTO_CR;
 
+    int ret = 0;
+
+    /* Initialize AUX subsystem handle */
+    ret = bcm2711_aux_sys_init(ops, &aux);
+    if (ret != 0) {
+        ZF_LOGE("Failed to initialize AUX subsystem! %i", ret);
+        return ret;
+    }
+
+    mini_uart_regs_t *regs = mini_uart_get_priv(dev);
+
+    /* Disable RX/TX and interrupts */
+    ret = mini_uart_disable(dev, &aux, false);
+    if (ret != 0) {
+        ZF_LOGE("Failed to disable mini-UART! %i", ret);
+        return ret;
+    }
+
+    /* Set databits to 8 and ensure DLAB == 0 */
+    regs->mu_lcr |= MU_LCR_DATASIZE;
+    regs->mu_lcr &= ~MU_LCR_DLAB;
+
+    /* Flush FIFO buffers and enable mini-UART */
+    ret = mini_uart_flush_fifos(dev);
+    if (ret != 0) {
+        ZF_LOGE("Failed to flush mini-UART FIFOs! %i", ret);
+        return ret;
+    }
+
+    ret = mini_uart_enable(dev, &aux);
+    if (ret != 0) {
+        ZF_LOGE("Failed to enable mini-UART! %i", ret);
+        return ret;
+    }
+
     return 0;
 }
 
 int mini_uart_getchar(ps_chardevice_t *d)
 {
-    while (!((mini_uart_regs_t *)d->vaddr)->mu_lsr & MU_LSR_DATAREADY);
-    return ((mini_uart_regs_t *)d->vaddr)->mu_io;
+    if (d == NULL) {
+        return -EINVAL;
+    }
+
+#if 0
+    if (d->flags & SERIAL_RX_NONBLOCKING) {
+        return mini_uart_getchar_nonblocking(d);
+    } else {
+        return mini_uart_getchar_blocking(d);
+    }
+#else
+    return mini_uart_getchar_nonblocking(d);
+#endif
 }
 
 int mini_uart_putchar(ps_chardevice_t *d, int c)
 {
-    while (!((mini_uart_regs_t *)d->vaddr)->mu_lsr & MU_LSR_TXIDLE);
-    ((mini_uart_regs_t *)d->vaddr)->mu_io = (c & 0xff);
+    if (d == NULL) {
+        return -EINVAL;
+    }
 
-    return 0;
+#if 0
+    if (d->flags & SERIAL_TX_NONBLOCKING) {
+        return mini_uart_putchar_nonblocking(d, c);
+    } else {
+        return mini_uart_putchar_blocking(d, c);
+    }
+#else
+    return mini_uart_putchar_blocking(d, c);
+#endif
 }

--- a/libplatsupport/src/plat/bcm2711/serial.c
+++ b/libplatsupport/src/plat/bcm2711/serial.c
@@ -164,7 +164,11 @@ int uart_init(const struct dev_defn *defn,
         break;
     }
 
-    uart_gpio_configure(defn->id, ops);
+    int ret = uart_gpio_configure(defn->id, ops);
+    if (0 != ret) {
+        ZF_LOGF("UART GPIO configuration failed. %i", ret);
+        return -1;
+    }
 
     uart_funcs.uart_init(defn, ops, dev);
 

--- a/libplatsupport/src/plat/bcm2711/serial.c
+++ b/libplatsupport/src/plat/bcm2711/serial.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright (C) 2021, Hensoldt Cyber GmbH
+ * Copyright 2022, Technology Innovation Institute
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -73,11 +74,13 @@ int uart_gpio_configure(enum chardev_id id, const ps_io_ops_t *o)
         tx_pin = 14;
         rx_pin = 15;
         alt_function = BCM2711_GPIO_FSEL_ALT0;
+        break;
     case 1:
         // UART 1 uses GPIO pins 14-15
         tx_pin = 14;
         rx_pin = 15;
         alt_function = BCM2711_GPIO_FSEL_ALT5;
+        break;
     case 2:
         // UART 2 uses GPIO pins 0-3
         tx_pin = 0;

--- a/libplatsupport/src/plat/bcm2711/serial.c
+++ b/libplatsupport/src/plat/bcm2711/serial.c
@@ -108,7 +108,6 @@ int uart_gpio_configure(enum chardev_id id, const ps_io_ops_t *o)
     default:
         ZF_LOGD("No pin configuration required!");
         return 0;
-        break;
     }
 
     if (tx_pin < 0 || rx_pin < 0) {
@@ -165,7 +164,7 @@ int uart_init(const struct dev_defn *defn,
     }
 
     int ret = uart_gpio_configure(defn->id, ops);
-    if (0 != ret) {
+    if (ret != 0) {
         ZF_LOGF("UART GPIO configuration failed. %i", ret);
         return -1;
     }


### PR DESCRIPTION
Add some error handling and trivial bugfix/naming fixes.

Add driver for the AUX peripheral block found on Raspberry Pi SoC's. 
The driver allows to explicitly enable/disable devices belonging to the 
AUX block, and to read IRQ statuses.

Update BCM2711 mini-UART driver to use the AUX driver.
Add non-blocking variants for "getchar()" and "putchar()" functions.
Also fix the BCM2711 mini-UART driver to use the non-blocking
variant of "getchar()", as the blocking variant hangs the system
if it is used with virtio-console. 