### PR TITLE
BCM2711 mini-UART fixes and updates

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -34,9 +34,11 @@ config_choice(
     "ega;LibPlatSupportX86ConsoleDeviceEGA;LIB_PLAT_SUPPORT_SERIAL_TEXT_EGA;KernelPlatPC99"
 )
 
+set(_link_arm_vm_Config_lib "")
 set(LibPlatSupportMach "")
 if(KernelPlatformRpi3 OR KernelPlatformRpi4)
     set(LibPlatSupportMach "bcm283x")
+    set(_link_arm_vm_Config_lib "arm_vm_Config")
 elseif(NOT ${KernelArmMach} STREQUAL "")
     # falling back to kernel settings is done to keep legacy compatibility
     set(LibPlatSupportMach "${KernelArmMach}")
@@ -164,6 +166,7 @@ target_link_libraries(
     utils
     fdt
     sel4_autoconf
+    ${_link_arm_vm_Config_lib}
     platsupport_Config
     ${irqchip_modules}
 )

--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/aux.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+#include <utils/util.h>
+#include <platsupport/io.h>
+
+#define BUS_ADDR_OFFSET     0x7E000000
+#define PADDR_OFFSET        0xFE000000
+
+/*
+ * The AUX block contains 3 auxiliary
+ * peripherals on the bcm2711 (section 2.1.)
+ *      find in seL4/tools/dts/rpi4.dts under
+ *          /soc/aux@7e215000
+ *          ->  /soc/serial@7e215040
+ *          ->  /soc/spi@7e215080
+ *          ->  /soc/spi@7e2150c0
+ */
+#define AUX_BUSADDR      0x7E215000
+
+#define AUX_PADDR        (AUX_BUSADDR - BUS_ADDR_OFFSET + PADDR_OFFSET)
+#define AUX_SIZE         0x1000
+
+/*
+ * BCM2711 TRM
+ * All AUX device interrupts are on the same interrupt #
+ * section 6.2.4. VideoCore interrupts:             29
+ * section 6.3.   GIC-400 - VC peripheral IRQs:     96
+ * => mini UART IRQ: 96 + 29 = 125
+ */
+#define AUX_IRQ          (125)
+
+typedef enum aux_dev_id {
+    BCM2711_AUX_UART,
+    BCM2711_AUX_SPI1,
+    BCM2711_AUX_SPI2,
+
+    NUM_AUX_DEV
+} aux_dev_id_t;
+
+typedef struct aux_sys aux_sys_t;
+
+struct aux_sys {
+    /** Get AUX device IRQ pending status.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 0/1 on success. Non-zero on error.
+     */
+    int (*get_irq_stat)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+    /**
+     * Query AUX device status.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 1 if device is enabled, 0 if not. <0 on error.
+     */
+    int (*status)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+    /**
+     * Enable AUX device.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 0 on success. Non-zero on error.
+     */
+    int (*enable)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+    /**
+     * Disable AUX device. Disabling an AUX device also
+     * disables access to the respective devices' registers.
+     * @param[in]   aux_sys    Initialized AUX driver instance.
+     * @param[in]   id         ID of the AUX device.
+     * @return 0 on success. Non-zero on error.
+     */
+    int (*disable)(aux_sys_t *aux_sys, aux_dev_id_t id);
+
+/// platform specific private data
+    void *priv;
+};
+
+/**
+ * Initialise the BCM2711 AUX system handler instance with externally mapped MMIO page.
+ * @param[in]  page      Mapping for AUX registers page.
+ * @param[out] aux_sys   Handle to AUX system instance to populate.
+ * @return               0 on success. Non-zero on error.
+ */
+int bcm2711_aux_sys_init_ext(void *page, aux_sys_t *aux_sys);
+
+/**
+ * Initialise the BCM2711 AUX system handler instance.
+ * @param[in]  io_ops    I/O operations for device initialisation.
+ * @param[out] aux_sys   Handle to AUX system instance to populate.
+ * @return               0 on success. Non-zero on error.
+ */
+int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys);
+
+/**
+ * De-initialise the BCM2711 AUX system handler instance.
+ * @param[in]  io_ops    I/O operations for device initialisation.
+ * @param[out] aux_sys   Handle to AUX system instance to populate.
+ * @return               0 on success. Non-zero on error.
+ */
+int bcm2711_aux_sys_destroy(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys);

--- a/libplatsupport/src/plat/bcm2711/aux.c
+++ b/libplatsupport/src/plat/bcm2711/aux.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2021, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <platsupport/plat/aux.h>
+#include "../../services.h"
+
+#define AUX_IRQ_MINIUART_IRQ  BIT(0) /* Mini-UART IRQ pending status bit. */
+#define AUX_IRQ_SPI1_IRQ      BIT(1) /* AUX SPI1 IRQ pending status bit. */
+#define AUX_IRQ_SPI2_IRQ      BIT(2) /* AUX SPI2 IRQ pending status bit. */
+
+#define AUX_ENA_MINIUART_ENA  BIT(0) /* Mini-UART enable/disable bit. */
+#define AUX_ENA_SPI1_ENA      BIT(1) /* AUX SPI1 enable/disable bit. */
+#define AUX_ENA_SPI2_ENA      BIT(2) /* AUX SPI2 enable/disable bit. */
+
+/* AUX registers definition. */
+typedef volatile struct {
+    uint32_t    aux_irq;  // 0x00: AUX IRQ pending status
+    uint32_t    aux_ena;  // 0x04: AUX device enable/disable
+} bcm2711_aux_regs_t;
+
+
+static struct bcm2711_aux {
+    bcm2711_aux_regs_t *regs;
+} aux_ctx;
+
+static inline bcm2711_aux_regs_t *aux_get_regs(aux_sys_t *aux_sys)
+{
+    return (((struct bcm2711_aux *)aux_sys->priv)->regs);
+};
+
+
+static int bcm2711_aux_get_irq_stat(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        ret = (int)(regs->aux_irq & AUX_IRQ_MINIUART_IRQ);
+        break;
+    case BCM2711_AUX_SPI1:
+        ret = (int)(regs->aux_irq & AUX_IRQ_SPI1_IRQ);
+        break;
+    case BCM2711_AUX_SPI2:
+        ret = (int)(regs->aux_irq & AUX_IRQ_SPI2_IRQ);
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+static int bcm2711_aux_status(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        ret = regs->aux_ena | AUX_ENA_MINIUART_ENA;
+        break;
+    case BCM2711_AUX_SPI1:
+        ret = regs->aux_ena | AUX_ENA_SPI1_ENA;
+        break;
+    case BCM2711_AUX_SPI2:
+        ret = regs->aux_ena | AUX_ENA_SPI2_ENA;
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+static int bcm2711_aux_enable(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        regs->aux_ena |= AUX_ENA_MINIUART_ENA;
+        break;
+    case BCM2711_AUX_SPI1:
+        regs->aux_ena |= AUX_ENA_SPI1_ENA;
+        break;
+    case BCM2711_AUX_SPI2:
+        regs->aux_ena |= AUX_ENA_SPI2_ENA;
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+static int bcm2711_aux_disable(aux_sys_t *aux_sys, aux_dev_id_t id)
+{
+    assert(aux_sys);
+    assert(aux_sys->priv);
+
+    int ret = 0;
+    bcm2711_aux_regs_t *regs = aux_get_regs(aux_sys);
+
+    switch (id) {
+    case BCM2711_AUX_UART:
+        regs->aux_ena &= ~AUX_ENA_MINIUART_ENA;
+        break;
+    case BCM2711_AUX_SPI1:
+        regs->aux_ena &= ~AUX_ENA_SPI1_ENA;
+        break;
+    case BCM2711_AUX_SPI2:
+        regs->aux_ena &= ~AUX_ENA_SPI2_ENA;
+        break;
+    default:
+        ZF_LOGE("AUX device ID is not in valid range!");
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+int bcm2711_aux_init_common(aux_sys_t *aux_sys)
+{
+    assert(aux_sys);
+
+    aux_sys->priv = (void *) &aux_ctx;
+    aux_sys->get_irq_stat = &bcm2711_aux_get_irq_stat;
+    aux_sys->status = &bcm2711_aux_status;
+    aux_sys->enable = &bcm2711_aux_enable;
+    aux_sys->disable = &bcm2711_aux_disable;
+
+    return 0;
+}
+
+int bcm2711_aux_sys_init_ext(void *page, aux_sys_t *aux_sys)
+{
+    if (page != NULL) {
+        aux_ctx.regs = page;
+
+        ZF_LOGD("Using externally mapped AUX registers frame: "
+                "vaddr -> 0x%" PRIxPTR, (uintptr_t)(aux_ctx.regs));
+
+        return bcm2711_aux_init_common(aux_sys);
+    }
+
+    return -EINVAL;
+}
+
+int bcm2711_aux_sys_init(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
+{
+    if ((io_ops == NULL)
+        || (aux_sys == NULL)) {
+        return -EINVAL;
+    }
+
+    MAP_IF_NULL(io_ops, AUX, aux_ctx.regs);
+    if (aux_ctx.regs == NULL) {
+        ZF_LOGF("Failed to map BCM2711 AUX registers frame.");
+        return -ENOMEM;
+    }
+
+    ZF_LOGD("Mapped AUX registers frame: "
+            "paddr / vaddr -> 0x% " PRIxPTR " / 0x% " PRIxPTR,
+            (uintptr_t) AUX_PADDR, (uintptr_t)(aux_ctx.regs));
+
+    return bcm2711_aux_init_common(aux_sys);
+}
+
+int bcm2711_aux_sys_destroy(const ps_io_ops_t *io_ops, aux_sys_t *aux_sys)
+{
+    if ((io_ops == NULL)
+        || (aux_sys == NULL)) {
+        return -EINVAL;
+    }
+
+    if (aux_sys->priv != NULL) {
+        ZF_LOGD("Unmapping AUX registers frame: vaddr -> 0x%" PRIxPTR, (uintptr_t)(aux_sys->priv));
+        ps_io_unmap(&(io_ops->io_mapper), aux_sys->priv, AUX_SIZE);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This pull request adds fixes and updates to BCM2711 mini-UART driver,
support for AUX peripheral block and support for virtio-con. 

AUX peripheral block driver allows for explicit control of peripherals
belonging to it (mini-UART, 2xSPI), and to query IRQ/enable status bits.

Mini-UART driver has been mostly rewritten:

- Enable support for all HW features.
- Add definitions for all registers/bits, add verbose comments.
- Add helper macros, move repeating code to inline functions.
- Improve code layout and error handling.
- Use AUX driver to explicitly enable/disable mini-UART.
- Support using mini-UART with virtio-console. Before these changes,
  the virtio-console would hang and couldn't be written to,
  if mini-UART was used as backend. The virtio-console needs 
  non-blocking getchar(), and to have RX interrupts enabled.
- Add ifdef guards to enable virtio-console functionality during compile-time.

Determining whether CONFIG_VM_VIRTIO_CON is set, the "arm_vm/gen_config.h"
header is needed, which is made available with "target_link_libraries" CMake macro.
A small string hackery is needed to avoid compile failures if the CAmkES ARM VM is
not used, or the platform is not ARM/BCM2711.

The BCM2711 UART drivers were changed to explicitly use GPIO driver for
UART pin initialization, but the GPIO driver is "broken". Here, "broken" means
that the driver itself works, but nothing would generate the necessary
device-untyped MMIO page mapping. Therefore, this PR needs the PR for
global-components merged also.
