### PR TITLE
libutils: compile_time_assert to support gnu99

### DIFF
--- a/libutils/include/utils/compile_time.h
+++ b/libutils/include/utils/compile_time.h
@@ -8,4 +8,10 @@
 
 #include <assert.h>
 
+/* 201112L indicates C11 */
+#if __STDC_VERSION__ < 201112L && !defined(__cplusplus)
+/* Use gcc extension for older C standards. */
+#define compile_time_assert(name, expr) _Static_assert((expr), #name)
+#else
 #define compile_time_assert(name, expr) static_assert((expr), #name)
+#endif


### PR DESCRIPTION
static_assert and _Static_assert were introduced to C11. However gcc and clang support _Static_assert for earlier versions. C23 deprecates _Static_assert and changes static_assert to keyword and will be removed from assert.h. Change compile_time_assert to take these into account.